### PR TITLE
Fikser parsing av utbetalingslinjer og mutering av tilstand

### DIFF
--- a/src/main/kotlin/no/nav/helse/behov/BehovProducer.kt
+++ b/src/main/kotlin/no/nav/helse/behov/BehovProducer.kt
@@ -5,13 +5,14 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 
 class BehovProducer(private val topic: String, private val producer: KafkaProducer<String, String>) {
-    companion object {
+    private companion object {
         private val log = LoggerFactory.getLogger(BehovProducer::class.java)
     }
 
-    fun sendNyttBehov(behov: Behov) =
-            producer.send(ProducerRecord(topic, behov.id().toString(), behov.toJson()))
-                    .get().also {
-                        log.info("produserte behov=$behov, recordMetadata=$it")
-                    }
+    fun sendNyttBehov(behov: Behov) {
+        producer.send(ProducerRecord(topic, behov.id().toString(), behov.toJson()))
+                .get().also {
+                    log.info("produserte behov=$behov, recordMetadata=$it")
+                }
+    }
 }

--- a/src/main/kotlin/no/nav/helse/person/Sakskompleks.kt
+++ b/src/main/kotlin/no/nav/helse/person/Sakskompleks.kt
@@ -309,7 +309,7 @@ class Sakskompleks internal constructor(
                     Utbetalingslinje(
                             fom = LocalDate.parse(it["fom"].textValue()),
                             tom = LocalDate.parse(it["tom"].textValue()),
-                            dagsats = it["dagsats"].textValue().toInt()
+                            dagsats = it["dagsats"].intValue()
                     )
                 }
                 godkjentAv = sakskompleksJson.godkjentAv

--- a/src/test/kotlin/no/nav/helse/unit/person/SakskompleksStateTest.kt
+++ b/src/test/kotlin/no/nav/helse/unit/person/SakskompleksStateTest.kt
@@ -385,6 +385,8 @@ internal class SakskompleksStateTest : SakskompleksObserver {
                 sakskompleksId = sakskompleksId
         ))
 
+        assertNull(sakskompleks.jsonRepresentation().maksdato, "skal ikke sette maksdato når saken skal manuelt behandles")
+        assertNull(sakskompleks.jsonRepresentation().utbetalingslinjer, "skal ikke sette utbetalingslinjer når saken skal manuelt behandles")
         assertEquals(KOMPLETT_SYKDOMSTIDSLINJE, lastStateEvent.previousState)
         assertEquals(TIL_INFOTRYGD, lastStateEvent.currentState)
     }

--- a/src/test/kotlin/no/nav/helse/unit/spleis/serde/JsonNodeUtilsKtTest.kt
+++ b/src/test/kotlin/no/nav/helse/unit/spleis/serde/JsonNodeUtilsKtTest.kt
@@ -11,12 +11,12 @@ import java.time.LocalDate
 internal class JsonNodeUtilsKtTest {
 
     companion object {
-        val objectMapper = jacksonObjectMapper()
+        private val objectMapper = jacksonObjectMapper()
             .registerModule(JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     }
 
-    val json = """
+    private val json = """
         {
             "felt1": null,
             "felt2": "2019-01-01"


### PR DESCRIPTION
- fikser at `int` blir deserialisert riktig. 
- Utvider `PersonMediator` med en test som kommer til å fange opp evt. slike feil i fremtiden
- tester at sakskompleks ikke oppdateres med maksdato og betalingslinjer når saken er ugyldig