### PR TITLE
Fikser feil i beregning av første dag for ytelser

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/UtgangspunktForBeregningAvYtelseVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/UtgangspunktForBeregningAvYtelseVisitor.kt
@@ -104,10 +104,6 @@ internal class UtgangspunktForBeregningAvYtelseVisitor : SykdomstidslinjeVisitor
         override fun implisittdag(utgangspunktForBeregningAvYtelseVisitor: UtgangspunktForBeregningAvYtelseVisitor) {
             utgangspunktForBeregningAvYtelseVisitor.state(MuligOpphold(førsteFraværsdag))
         }
-
-        override fun leaving(utgangspunktForBeregningAvYtelseVisitor: UtgangspunktForBeregningAvYtelseVisitor) {
-            utgangspunktForBeregningAvYtelseVisitor.førsteFraværsdag = null
-        }
     }
 
     private class MuligOpphold(private val kanskjeFørsteFraværsdag: LocalDate): FørsteFraværsdagTilstand {

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/sykdomstidslinje/UtgangspunktForBeregningAvYtelseVisitorTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/sykdomstidslinje/UtgangspunktForBeregningAvYtelseVisitorTest.kt
@@ -23,13 +23,6 @@ internal class UtgangspunktForBeregningAvYtelseVisitorTest {
         assertUgyldigTilstand(1.permisjonsdager)
         assertUgyldigTilstand(1.implisittDager)
         assertUgyldigTilstand(1.arbeidsdager)
-        assertUgyldigTilstand(1.sykedager + 1.utenlandsdager)
-        assertUgyldigTilstand(1.sykedager + 1.utenlandsdager + 1.sykedager)
-        assertUgyldigTilstand(1.sykedager + 1.studieDager)
-        assertUgyldigTilstand(1.sykedager + 1.studieDager + 1.sykedager)
-        assertUgyldigTilstand(1.sykedager + 1.implisittDager + 1.arbeidsdager)
-        assertUgyldigTilstand(1.sykedager + 1.implisittDager + 1.studieDager)
-        assertUgyldigTilstand(1.sykedager + 1.implisittDager + 1.utenlandsdager)
     }
 
     @Test
@@ -79,9 +72,24 @@ internal class UtgangspunktForBeregningAvYtelseVisitorTest {
     }
 
     @Test
-    internal fun `tidslinjer som slutter med dager som ikke er sykedager, egenmeldingsdager eller sykHelgedag`() {
-        assertUgyldigTilstand(1.sykedager + 1.arbeidsdager)
-        assertUgyldigTilstand(1.sykedager + 1.implisittDager)
+    internal fun `sykedager etterfulgt av arbeidsdager`() {
+        perioder(2.sykedager, 2.arbeidsdager) { sykedager, _ ->
+            assertFørsteDagErUtgangspunktForBeregning(sykedager, this)
+        }
+    }
+
+    @Test
+    internal fun `sykedager etterfulgt av implisittdager`() {
+        perioder(2.sykedager, 2.implisittDager) { sykedager, _ ->
+            assertFørsteDagErUtgangspunktForBeregning(sykedager, this)
+        }
+    }
+
+    @Test
+    internal fun `søknad med arbeidgjenopptatt gir ikke feil`() {
+        perioder(2.sykedager, 2.implisittDager) { sykedager, _ ->
+            assertFørsteDagErUtgangspunktForBeregning(sykedager, this)
+        }
     }
 
     companion object {


### PR DESCRIPTION
Jeg mener det ikke er noen god grunn til å sette første fraværsdag til null når vi oppdager en ny periode siden vi ikke bruker nulltilstanden til noe. Vi har en del tilstander der vi har sykedager etterfulgt av en eller annen dagtype - og da er det bedre å bruke den beste sykedagen vi har, enn å kaste en feil. Har derfor relaxet en del av de litt rare casene slik at de ikke lenger tryner.