### PR TITLE
skiller ny, fremtidig og sendt søknad, fordi de har ulik validering

### DIFF
--- a/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/MessageProcessor.kt
+++ b/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/MessageProcessor.kt
@@ -1,13 +1,12 @@
 package no.nav.helse.spleis.hendelser
 
-import no.nav.helse.spleis.hendelser.model.BehovMessage
-import no.nav.helse.spleis.hendelser.model.InntektsmeldingMessage
-import no.nav.helse.spleis.hendelser.model.PåminnelseMessage
-import no.nav.helse.spleis.hendelser.model.SøknadMessage
+import no.nav.helse.spleis.hendelser.model.*
 
 // Acts as a GoF visitor
 internal interface MessageProcessor {
-    fun process(message: SøknadMessage, problems: MessageProblems)
+    fun process(message: NySøknadMessage, problems: MessageProblems)
+    fun process(message: FremtidigSøknadMessage, problems: MessageProblems)
+    fun process(message: SendtSøknadMessage, problems: MessageProblems)
     fun process(message: InntektsmeldingMessage, problems: MessageProblems)
     fun process(message: BehovMessage, problems: MessageProblems)
     fun process(message: PåminnelseMessage, problems: MessageProblems)

--- a/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/FremtidigSøknadMessage.kt
+++ b/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/FremtidigSøknadMessage.kt
@@ -1,0 +1,23 @@
+package no.nav.helse.spleis.hendelser.model
+
+import no.nav.helse.spleis.hendelser.MessageFactory
+import no.nav.helse.spleis.hendelser.MessageProblems
+import no.nav.helse.spleis.hendelser.MessageProcessor
+
+// Understands a JSON message representing a Søknad
+internal class FremtidigSøknadMessage(originalMessage: String, private val problems: MessageProblems) :
+    SøknadMessage(originalMessage, problems) {
+    init {
+        requiredValue("status", "FREMTIDIG")
+    }
+
+    override fun accept(processor: MessageProcessor) {
+        processor.process(this, problems)
+    }
+
+    object Factory : MessageFactory<FremtidigSøknadMessage> {
+
+        override fun createMessage(message: String, problems: MessageProblems) =
+            FremtidigSøknadMessage(message, problems)
+    }
+}

--- a/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/NySøknadMessage.kt
+++ b/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/NySøknadMessage.kt
@@ -1,0 +1,23 @@
+package no.nav.helse.spleis.hendelser.model
+
+import no.nav.helse.spleis.hendelser.MessageFactory
+import no.nav.helse.spleis.hendelser.MessageProblems
+import no.nav.helse.spleis.hendelser.MessageProcessor
+
+// Understands a JSON message representing a Søknad
+internal class NySøknadMessage(originalMessage: String, private val problems: MessageProblems) :
+    SøknadMessage(originalMessage, problems) {
+    init {
+        requiredValue("status", "NY")
+    }
+
+    override fun accept(processor: MessageProcessor) {
+        processor.process(this, problems)
+    }
+
+    object Factory : MessageFactory<NySøknadMessage> {
+
+        override fun createMessage(message: String, problems: MessageProblems) =
+            NySøknadMessage(message, problems)
+    }
+}

--- a/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/SendtSøknadMessage.kt
+++ b/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/SendtSøknadMessage.kt
@@ -1,0 +1,24 @@
+package no.nav.helse.spleis.hendelser.model
+
+import no.nav.helse.spleis.hendelser.MessageFactory
+import no.nav.helse.spleis.hendelser.MessageProblems
+import no.nav.helse.spleis.hendelser.MessageProcessor
+
+// Understands a JSON message representing a Søknad
+internal class SendtSøknadMessage(originalMessage: String, private val problems: MessageProblems) :
+    SøknadMessage(originalMessage, problems) {
+    init {
+        requiredValue("status", "SENDT")
+        requiredKey("sendtNav")
+    }
+
+    override fun accept(processor: MessageProcessor) {
+        processor.process(this, problems)
+    }
+
+    object Factory : MessageFactory<SendtSøknadMessage> {
+
+        override fun createMessage(message: String, problems: MessageProblems) =
+            SendtSøknadMessage(message, problems)
+    }
+}

--- a/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/SøknadMessage.kt
+++ b/sykepenger-mediators/src/main/kotlin/no/nav/helse/spleis/hendelser/model/SøknadMessage.kt
@@ -1,27 +1,15 @@
 package no.nav.helse.spleis.hendelser.model
 
 import no.nav.helse.spleis.hendelser.JsonMessage
-import no.nav.helse.spleis.hendelser.MessageFactory
 import no.nav.helse.spleis.hendelser.MessageProblems
-import no.nav.helse.spleis.hendelser.MessageProcessor
 
 // Understands a JSON message representing a Søknad
-internal class SøknadMessage(originalMessage: String, private val problems: MessageProblems) :
+internal abstract class SøknadMessage(originalMessage: String, problems: MessageProblems) :
     JsonMessage(originalMessage, problems) {
     init {
         requiredKey("id", "type", "status",
             "fnr", "aktorId", "arbeidsgiver", "fom", "tom", "startSyketilfelle",
-            "opprettet", "sendtNav", "egenmeldinger",
+            "opprettet", "egenmeldinger",
             "fravar", "soknadsperioder")
-    }
-
-    override fun accept(processor: MessageProcessor) {
-        processor.process(this, problems)
-    }
-
-    object Factory : MessageFactory<SøknadMessage> {
-
-        override fun createMessage(message: String, problems: MessageProblems) =
-            SøknadMessage(message, problems)
     }
 }

--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/e2e/EndToEndTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/e2e/EndToEndTest.kt
@@ -12,8 +12,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.util.KtorExperimentalAPI
 import no.nav.common.KafkaEnvironment
-import no.nav.helse.ApplicationBuilder
-import no.nav.helse.SpolePeriode
+import no.nav.helse.*
 import no.nav.helse.TestConstants.inntektsmeldingDTO
 import no.nav.helse.TestConstants.påminnelseHendelse
 import no.nav.helse.TestConstants.søknadDTO
@@ -26,18 +25,10 @@ import no.nav.helse.Topics.vedtaksperiodeEventTopic
 import no.nav.helse.Topics.vedtaksperiodeSlettetEventTopic
 import no.nav.helse.behov.Behov
 import no.nav.helse.behov.Behovstype
-import no.nav.helse.behov.Behovstype.EgenAnsatt
-import no.nav.helse.behov.Behovstype.GodkjenningFraSaksbehandler
-import no.nav.helse.behov.Behovstype.Sykepengehistorikk
-import no.nav.helse.behov.Behovstype.Utbetaling
-import no.nav.helse.handleRequest
+import no.nav.helse.behov.Behovstype.*
 import no.nav.helse.hendelser.Påminnelse
-import no.nav.helse.løsBehov
 import no.nav.helse.person.Person
 import no.nav.helse.person.TilstandType
-import no.nav.helse.randomPort
-import no.nav.helse.responseBody
-import no.nav.helse.toJsonNode
 import no.nav.inntektsmeldingkontrakt.Inntektsmelding
 import no.nav.syfo.kafka.sykepengesoknad.dto.ArbeidsgiverDTO
 import no.nav.syfo.kafka.sykepengesoknad.dto.SoknadsstatusDTO
@@ -50,10 +41,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG
-import org.apache.kafka.clients.producer.ProducerConfig.LINGER_MS_CONFIG
-import org.apache.kafka.clients.producer.ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION
-import org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG
+import org.apache.kafka.clients.producer.ProducerConfig.*
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
@@ -62,20 +50,14 @@ import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions.assertDoesNotThrow
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
 import java.time.Duration
 import java.time.Duration.ofMillis
-import java.util.HashMap
-import java.util.Properties
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.TimeUnit.SECONDS
 
 @KtorExperimentalAPI
@@ -484,7 +466,7 @@ internal class EndToEndTest {
             fødselsnummer = fødselsnummer,
             arbeidsgiver = ArbeidsgiverDTO(orgnummer = virksomhetsnummer),
             status = SoknadsstatusDTO.NY
-        )
+        ).copy(sendtNav = null)
     ): SykepengesoknadDTO {
         synchronousSendKafkaMessage(søknadTopic, nySøknad.id!!, nySøknad.toJsonNode().toString())
         return nySøknad

--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/unit/spleis/hendelser/model/FremtidigSøknadMessageTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/unit/spleis/hendelser/model/FremtidigSøknadMessageTest.kt
@@ -1,0 +1,100 @@
+package no.nav.helse.unit.spleis.hendelser.model
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.helse.spleis.hendelser.MessageProblems
+import no.nav.helse.spleis.hendelser.model.FremtidigSøknadMessage
+import no.nav.syfo.kafka.sykepengesoknad.dto.*
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+internal class FremtidigSøknadMessageTest {
+
+    private val InvalidJson = "foo"
+    private val UnknownJson = "{\"foo\": \"bar\"}"
+    private val ValidSøknad = SykepengesoknadDTO(
+        id = UUID.randomUUID().toString(),
+        type = SoknadstypeDTO.ARBEIDSTAKERE,
+        status = SoknadsstatusDTO.FREMTIDIG,
+        aktorId = "aktørId",
+        fnr = "fødselsnummer",
+        sykmeldingId = UUID.randomUUID().toString(),
+        arbeidsgiver = ArbeidsgiverDTO(navn = "arbeidsgiver", orgnummer = "orgnr"),
+        arbeidssituasjon = ArbeidssituasjonDTO.ARBEIDSTAKER,
+        arbeidsgiverForskutterer = ArbeidsgiverForskuttererDTO.JA,
+        fom = LocalDate.now(),
+        tom = LocalDate.now(),
+        startSyketilfelle = LocalDate.now(),
+        arbeidGjenopptatt = LocalDate.now(),
+        korrigerer = "korrigerer",
+        opprettet = LocalDateTime.now(),
+        sendtNav = null,
+        sendtArbeidsgiver = LocalDateTime.now(),
+        egenmeldinger = listOf(PeriodeDTO(fom = LocalDate.now(), tom = LocalDate.now())),
+        soknadsperioder = listOf(SoknadsperiodeDTO(
+            fom = LocalDate.now(),
+            tom = LocalDate.now(),
+            sykmeldingsgrad = 100,
+            faktiskGrad = 100,
+            avtaltTimer = Double.MIN_VALUE,
+            faktiskTimer = Double.MAX_VALUE,
+            sykmeldingstype = SykmeldingstypeDTO.AKTIVITET_IKKE_MULIG
+        )),
+        fravar = listOf(FravarDTO(fom = LocalDate.now(), tom = LocalDate.now()))
+    )
+
+    private val ValidFremtidigSøknad = ValidSøknad.copy(status = SoknadsstatusDTO.FREMTIDIG).toJson()
+    private val ValidAvbruttSøknad = ValidSøknad.copy(status = SoknadsstatusDTO.AVBRUTT).toJson()
+    private val ValidFremtidigSøknadWithUnknownFieldsJson = ValidSøknad.copy(status = SoknadsstatusDTO.FREMTIDIG).asJsonNode().let {
+        it as ObjectNode
+        it.put(UUID.randomUUID().toString(), "foobar")
+    }.toJson()
+
+    @Test
+    internal fun `invalid messages`() {
+        assertInvalidMessage(InvalidJson)
+        assertInvalidMessage(UnknownJson)
+        assertInvalidMessage(ValidAvbruttSøknad)
+    }
+
+    @Test
+    internal fun `valid søknader`() {
+        assertValidSøknadMessage(ValidFremtidigSøknadWithUnknownFieldsJson)
+        assertValidSøknadMessage(ValidFremtidigSøknad)
+    }
+
+    private fun assertValidSøknadMessage(message: String) {
+        val problems = MessageProblems(message)
+        FremtidigSøknadMessage(message, problems)
+        assertFalse(problems.hasErrors()) { "was supposed to recognize $message: $problems" }
+    }
+
+    private fun assertInvalidMessage(message: String) {
+        MessageProblems(message).also {
+            FremtidigSøknadMessage(message, it)
+            assertTrue(it.hasErrors()) { "was not supposed to recognize $message" }
+        }
+    }
+
+    private var recognizedSøknad = false
+    @BeforeEach
+    fun reset() {
+        recognizedSøknad = false
+    }
+}
+
+private val objectMapper = jacksonObjectMapper()
+    .registerModule(JavaTimeModule())
+    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+private fun SykepengesoknadDTO.asJsonNode(): JsonNode = objectMapper.valueToTree(this)
+private fun SykepengesoknadDTO.toJson(): String = objectMapper.writeValueAsString(this)
+private fun JsonNode.toJson(): String = objectMapper.writeValueAsString(this)

--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/unit/spleis/hendelser/model/SendtSøknadMessageTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/unit/spleis/hendelser/model/SendtSøknadMessageTest.kt
@@ -1,0 +1,100 @@
+package no.nav.helse.unit.spleis.hendelser.model
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.helse.spleis.hendelser.MessageProblems
+import no.nav.helse.spleis.hendelser.model.SendtSøknadMessage
+import no.nav.syfo.kafka.sykepengesoknad.dto.*
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+internal class SendtSøknadMessageTest {
+
+    private val InvalidJson = "foo"
+    private val UnknownJson = "{\"foo\": \"bar\"}"
+    private val ValidSøknad = SykepengesoknadDTO(
+        id = UUID.randomUUID().toString(),
+        type = SoknadstypeDTO.ARBEIDSTAKERE,
+        status = SoknadsstatusDTO.SENDT,
+        aktorId = "aktørId",
+        fnr = "fødselsnummer",
+        sykmeldingId = UUID.randomUUID().toString(),
+        arbeidsgiver = ArbeidsgiverDTO(navn = "arbeidsgiver", orgnummer = "orgnr"),
+        arbeidssituasjon = ArbeidssituasjonDTO.ARBEIDSTAKER,
+        arbeidsgiverForskutterer = ArbeidsgiverForskuttererDTO.JA,
+        fom = LocalDate.now(),
+        tom = LocalDate.now(),
+        startSyketilfelle = LocalDate.now(),
+        arbeidGjenopptatt = LocalDate.now(),
+        korrigerer = "korrigerer",
+        opprettet = LocalDateTime.now(),
+        sendtNav = LocalDateTime.now(),
+        sendtArbeidsgiver = LocalDateTime.now(),
+        egenmeldinger = listOf(PeriodeDTO(fom = LocalDate.now(), tom = LocalDate.now())),
+        soknadsperioder = listOf(SoknadsperiodeDTO(
+            fom = LocalDate.now(),
+            tom = LocalDate.now(),
+            sykmeldingsgrad = 100,
+            faktiskGrad = 100,
+            avtaltTimer = Double.MIN_VALUE,
+            faktiskTimer = Double.MAX_VALUE,
+            sykmeldingstype = SykmeldingstypeDTO.AKTIVITET_IKKE_MULIG
+        )),
+        fravar = listOf(FravarDTO(fom = LocalDate.now(), tom = LocalDate.now()))
+    )
+
+    private val ValidSendtSøknad = ValidSøknad.copy(status = SoknadsstatusDTO.SENDT).toJson()
+    private val ValidAvbruttSøknad = ValidSøknad.copy(status = SoknadsstatusDTO.AVBRUTT).toJson()
+    private val ValidSendtSøknadWithUnknownFieldsJson = ValidSøknad.copy(status = SoknadsstatusDTO.SENDT).asJsonNode().let {
+        it as ObjectNode
+        it.put(UUID.randomUUID().toString(), "foobar")
+    }.toJson()
+
+    @Test
+    internal fun `invalid messages`() {
+        assertInvalidMessage(InvalidJson)
+        assertInvalidMessage(UnknownJson)
+        assertInvalidMessage(ValidAvbruttSøknad)
+    }
+
+    @Test
+    internal fun `valid søknader`() {
+        assertValidSøknadMessage(ValidSendtSøknadWithUnknownFieldsJson)
+        assertValidSøknadMessage(ValidSendtSøknad)
+    }
+
+    private fun assertValidSøknadMessage(message: String) {
+        val problems = MessageProblems(message)
+        SendtSøknadMessage(message, problems)
+        assertFalse(problems.hasErrors()) { "was supposed to recognize $message: $problems" }
+    }
+
+    private fun assertInvalidMessage(message: String) {
+        MessageProblems(message).also {
+            SendtSøknadMessage(message, it)
+            assertTrue(it.hasErrors()) { "was not supposed to recognize $message" }
+        }
+    }
+
+    private var recognizedSøknad = false
+    @BeforeEach
+    fun reset() {
+        recognizedSøknad = false
+    }
+}
+
+private val objectMapper = jacksonObjectMapper()
+    .registerModule(JavaTimeModule())
+    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+private fun SykepengesoknadDTO.asJsonNode(): JsonNode = objectMapper.valueToTree(this)
+private fun SykepengesoknadDTO.toJson(): String = objectMapper.writeValueAsString(this)
+private fun JsonNode.toJson(): String = objectMapper.writeValueAsString(this)


### PR DESCRIPTION
Sendte søknader krever at `sendtNav` er satt, det gjør ikke nye og fremtidige