### PR TITLE
Fikser classloading-issue mellom kotlin og jackson

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,15 @@ allprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
     dependencies {
+        implementation("org.jetbrains.kotlin:kotlin-reflect:1.4.0")
         implementation("ch.qos.logback:logback-classic:1.2.3")
         implementation("net.logstash.logback:logstash-logback-encoder:6.4") {
             exclude("com.fasterxml.jackson.core")
             exclude("com.fasterxml.jackson.dataformat")
         }
-        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion") {
+            exclude("org.jetbrains.kotlin:kotlin-reflect")
+        }
         implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
 
         implementation("com.zaxxer:HikariCP:$hikariVersion")


### PR DESCRIPTION
Vi får en classloadingwarning fordi jackson drar inn kotlin-reflect(1.3.72) og vi indirekte drar inn 1.4.0 sammen med kotlin.stdlib.

Tror dette ordner opp i det. Det tar iallefall bort warningen 🤷‍♂️ 