### PR TITLE
Gjør tester for inntektshistorikk platformuavhengig

### DIFF
--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/InntektshistorikkVol2Test.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/InntektshistorikkVol2Test.kt
@@ -301,6 +301,7 @@ internal class InntektshistorikkVol2Test {
             1.desember(2016) til 1.august(2017) inntekter {
                 ORGNUMMER inntekt INNTEKT
             }
+            Thread.sleep(10) // Nødvendig for konsistent resultat på windows
         }.forEach { it.lagreInntekter(historikk, 1.januar(2018), UUID.randomUUID()) }
         assertEquals(2, inspektør.inntektTeller.size)
         assertEquals(9, inspektør.inntektTeller.first())
@@ -319,6 +320,7 @@ internal class InntektshistorikkVol2Test {
                 1.desember(2016) til 1.august(2017) inntekter {
                     ORGNUMMER inntekt INNTEKT
                 }
+                Thread.sleep(10) // Nødvendig for konsistent resultat på windows
             }.forEach { it.lagreInntekter(historikk, 1.januar, meldingsreferanseId) }
         }
 


### PR DESCRIPTION
Disse testene er avhengig av LocalDateTime.now(), og dette gir problemer på windows på grunn av nøyaktigheten på klokken. Denne sleepen skal garantere at den tolker at inntekten kom inn på forskjellig tidspunkt