### PR TITLE
Send hendelsen ned i alle vedtaksperiodene på arbeidsgiver selv om listen muteres underveis

### DIFF
--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverMediatorTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverMediatorTest.kt
@@ -340,8 +340,8 @@ internal class KunEnArbeidsgiverMediatorTest : AbstractEndToEndMediatorTest() {
         sendUtbetalingshistorikk(1)
         sendNyPåminnelse(1, TilstandType.AVVENTER_INNTEKTSMELDING_ELLER_HISTORIKK_FERDIG_GAP)
 
-        assertTilstander(0, "MOTTATT_SYKMELDING_FERDIG_GAP", "AVSLUTTET_UTEN_UTBETALING", "TIL_INFOTRYGD")
-        assertTilstander(1, "MOTTATT_SYKMELDING_FERDIG_GAP", "AVVENTER_INNTEKTSMELDING_ELLER_HISTORIKK_FERDIG_GAP", "TIL_INFOTRYGD")
+        assertForkastedeTilstander(0, "MOTTATT_SYKMELDING_FERDIG_GAP", "AVSLUTTET_UTEN_UTBETALING")
+        assertForkastedeTilstander(1, "MOTTATT_SYKMELDING_FERDIG_GAP", "AVVENTER_INNTEKTSMELDING_ELLER_HISTORIKK_FERDIG_GAP", "TIL_INFOTRYGD")
     }
 
     @Test

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
@@ -158,7 +158,8 @@ internal class Vedtaksperiode private constructor(
                 kontekst(inntektsmelding)
                 inntektsmelding.error("Refusjon opphører i perioden")
                 inntektsmelding.trimLeft(periode.endInclusive)
-                return@also tilstand(inntektsmelding, TilInfotrygd)
+                arbeidsgiver.søppelbøtte(inntektsmelding, SENERE_INCLUSIVE(this), IKKE_STØTTET)
+                return@also
             }
             if (!it) return@also inntektsmelding.trimLeft(periode.endInclusive)
             kontekst(inntektsmelding)
@@ -339,7 +340,10 @@ internal class Vedtaksperiode private constructor(
             }
         }
         hendelse.valider(periode)
-        if (hendelse.hasErrorsOrWorse()) return tilstand(hendelse, TilInfotrygd)
+        if (hendelse.hasErrorsOrWorse()) {
+            arbeidsgiver.søppelbøtte(hendelse, SENERE_INCLUSIVE(this), IKKE_STØTTET)
+            return
+        }
         hvisIngenErrors()
         hendelse.info("Fullført behandling av inntektsmelding")
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/InntektsmeldingE2ETest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/InntektsmeldingE2ETest.kt
@@ -847,7 +847,6 @@ internal class InntektsmeldingE2ETest : AbstractEndToEndTest() {
     }
 
     @Test
-    @Disabled("Her forventer vi at alle periodene skal forkastes, men det skjer ikke.")
     fun `Inntektsmelding med error som treffer flere perioder`() {
         håndterSykmelding(Sykmeldingsperiode(29.mars(2021), 31.mars(2021), 100.prosent))
         håndterSykmelding(Sykmeldingsperiode(6.april(2021), 17.april(2021), 100.prosent))
@@ -868,7 +867,6 @@ internal class InntektsmeldingE2ETest : AbstractEndToEndTest() {
             START,
             MOTTATT_SYKMELDING_FERDIG_GAP,
             AVSLUTTET_UTEN_UTBETALING,
-            TIL_INFOTRYGD
         )
 
         assertForkastetPeriodeTilstander(
@@ -877,7 +875,47 @@ internal class InntektsmeldingE2ETest : AbstractEndToEndTest() {
             MOTTATT_SYKMELDING_UFERDIG_GAP,
             MOTTATT_SYKMELDING_FERDIG_GAP,
             AVSLUTTET_UTEN_UTBETALING,
+        )
+
+        assertForkastetPeriodeTilstander(
+            3.vedtaksperiode,
+            START,
+            MOTTATT_SYKMELDING_UFERDIG_FORLENGELSE,
+            MOTTATT_SYKMELDING_FERDIG_FORLENGELSE,
+            AVVENTER_INNTEKTSMELDING_FERDIG_FORLENGELSE,
             TIL_INFOTRYGD
+        )
+    }
+
+    @Test
+    fun `Inntektsmelding med error som treffer flere perioder uten gap`() {
+        håndterSykmelding(Sykmeldingsperiode(29.mars(2021), 31.mars(2021), 100.prosent))
+        håndterSykmelding(Sykmeldingsperiode(1.april(2021), 17.april(2021), 100.prosent))
+        håndterSøknadArbeidsgiver(SøknadArbeidsgiver.Søknadsperiode(29.mars(2021), 31.mars(2021), 100.prosent))
+        håndterSykmelding(Sykmeldingsperiode(18.april(2021), 2.mai(2021), 100.prosent))
+        håndterSøknadArbeidsgiver(SøknadArbeidsgiver.Søknadsperiode(1.april(2021), 17.april(2021), 100.prosent))
+        håndterSøknad(Sykdom(18.april(2021), 2.mai(2021), 100.prosent))
+
+        håndterInntektsmeldingMedValidering(
+            1.vedtaksperiode,
+            listOf(Periode(29.mars(2021), 31.mars(2021)), Periode(1.april(2021), 12.april(2021))),
+            refusjon = Triple(null, INNTEKT, emptyList()),
+            beregnetInntekt = INGEN
+        )
+
+        assertForkastetPeriodeTilstander(
+            1.vedtaksperiode,
+            START,
+            MOTTATT_SYKMELDING_FERDIG_GAP,
+            AVSLUTTET_UTEN_UTBETALING,
+        )
+
+        assertForkastetPeriodeTilstander(
+            2.vedtaksperiode,
+            START,
+            MOTTATT_SYKMELDING_UFERDIG_FORLENGELSE,
+            MOTTATT_SYKMELDING_FERDIG_FORLENGELSE,
+            AVSLUTTET_UTEN_UTBETALING
         )
 
         assertForkastetPeriodeTilstander(


### PR DESCRIPTION
Vi har en utfordring knyttet til hendelser som treffer flere perioder og samtidig kaster ut perioder fortløpende. Dagens implementasjon stopper løkka ved første endring i vedtaksperiodelista. Det medfører at etterfølgende perioder med gap som også skulle kastes ikke får det med seg.

Vi tror at ved å ta en kopi av lista som beholder referansene til orginalen så kan vi komme oss rundt at den modifiseres løpende. Vi hindrer behandling i forkastede perioder ved å sjekke opp i orginallisten før vi kallen handleren.