### PR TITLE
Slår sammen forskjellige tidslinjer ved hjelp av dato ranges

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/Toggles.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/Toggles.kt
@@ -48,4 +48,5 @@ abstract class Toggles internal constructor(enabled: Boolean = false, private va
     object SendFeriepengeOppdrag: Toggles(true)
     object KastAlleRevurderinger: Toggles("KAST_ALLE_REVURDERINGER")
     object RevurderTidligerePeriode: Toggles("REVURDER_TIDLIGERE_PERIODE")
+    object DatoRangeJson : Toggles(true)
 }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/DateRange.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/DateRange.kt
@@ -29,6 +29,8 @@ sealed class DateRange {
     }
 
     companion object {
+        // Siden jackson ikke støtter custom deserializer for @JsonUnwrapped og vi ikke kan ha to JsonCreators per klasse må de dele en creator og finne ut
+        // hvilke type det er ut i fra hvilke dataer som mangler
         @JvmStatic
         @JsonCreator
         private fun create(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/DateRange.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/DateRange.kt
@@ -43,16 +43,6 @@ sealed class DateRange {
     }
 }
 
-data class DataHolder(
-    var range: DateRange,
-    val extraData: Map<String, Any?>
-) {
-    fun toMap() = extraData + range.toMap()
-
-    fun canBeJoinedBy(date: LocalDate, data: Map<String, Any?>) =
-        range.canBeJoinedBy(date) && extraData == data
-}
-
 class DateRanges {
     private val ranges = mutableListOf<DataHolder>()
     fun plus(date: LocalDate, data: Map<String, Any?>) = apply {
@@ -65,4 +55,14 @@ class DateRanges {
     }
 
     fun toList() = ranges.map { it.toMap() }
+
+    private class DataHolder(
+        var range: DateRange,
+        val extraData: Map<String, Any?>
+    ) {
+        fun toMap() = extraData + range.toMap()
+
+        fun canBeJoinedBy(date: LocalDate, data: Map<String, Any?>) =
+            range.canBeJoinedBy(date) && extraData == data
+    }
 }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/DateRange.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/DateRange.kt
@@ -1,0 +1,68 @@
+package no.nav.helse.serde
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import no.nav.helse.Toggles
+import java.time.LocalDate
+import kotlin.streams.toList
+
+sealed class DateRange {
+    abstract fun dates(): List<LocalDate>
+    abstract fun toMap(): Map<String, LocalDate>
+    abstract operator fun plus(other: LocalDate): DateRange
+    abstract fun canBeJoinedBy(other: LocalDate): Boolean
+
+    class Single(val dato: LocalDate) : DateRange() {
+        override fun dates(): List<LocalDate> = listOf(dato)
+        override fun toMap(): Map<String, LocalDate> = mapOf("dato" to dato)
+        override fun plus(other: LocalDate) = Range(dato, other)
+        override fun canBeJoinedBy(other: LocalDate): Boolean =
+            dato.plusDays(1) == other
+    }
+
+    class Range(val fom: LocalDate, val tom: LocalDate) : DateRange() {
+        override fun dates(): List<LocalDate> = fom.datesUntil(tom.plusDays(1)).toList()
+        override fun toMap(): Map<String, LocalDate> = mapOf("fom" to fom, "tom" to tom)
+        override fun plus(other: LocalDate) = Range(fom, other)
+        override fun canBeJoinedBy(other: LocalDate): Boolean =
+            tom.plusDays(1) == other
+    }
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        private fun create(
+            @JsonProperty("dato") dato: LocalDate?,
+            @JsonProperty("fom") fom: LocalDate?,
+            @JsonProperty("tom") tom: LocalDate?
+        ) = if (dato == null) {
+            Range(fom!!, tom!!)
+        } else {
+            Single(dato)
+        }
+    }
+}
+
+data class DataHolder(
+    var range: DateRange,
+    val extraData: Map<String, Any?>
+) {
+    fun toMap() = extraData + range.toMap()
+
+    fun canBeJoinedBy(date: LocalDate, data: Map<String, Any?>) =
+        range.canBeJoinedBy(date) && extraData == data
+}
+
+class DateRanges {
+    private val ranges = mutableListOf<DataHolder>()
+    fun plus(date: LocalDate, data: Map<String, Any?>) = apply {
+        val last = ranges.lastOrNull()
+        if (last != null && last.canBeJoinedBy(date, data) && Toggles.DatoRangeJson.enabled) {
+            last.range += date
+        } else {
+            ranges.add(DataHolder(DateRange.Single(date), data))
+        }
+    }
+
+    fun toList() = ranges.map { it.toMap() }
+}

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/PersonData.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/PersonData.kt
@@ -534,6 +534,7 @@ internal data class PersonData(
                 private val er6GBegrenset: Boolean?,
                 private val melding: String?
             ) {
+                // Gjør så vi kan ha dato/fom og tom på samme nivå som resten av verdiene i dag
                 @JsonUnwrapped
                 private lateinit var datoer: DateRange
 
@@ -1102,6 +1103,7 @@ internal data class PersonData(
             private val personbeløp: Double?,
             private val er6GBegrenset: Boolean?
         ) {
+            // Gjør så vi kan ha dato/fom og tom på samme nivå som resten av verdiene i utbetalingsdata
             @JsonUnwrapped
             private lateinit var datoer: DateRange
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/reflection/DagReflect.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/reflection/DagReflect.kt
@@ -13,7 +13,6 @@ internal fun serialisertSykdomstidslinjedag(
     melding: String? = null
 ) =
     mutableMapOf<String, Any>().also { map ->
-        map["dato"] = dag["dato"]
         map["type"] = dag.toJsonType()
         map["kilde"] = kilde.toJson()
         dag.maybe<Økonomi?>("økonomi")?.let { økonomi ->
@@ -35,9 +34,9 @@ private fun Dag.toJsonType() = when (this) {
     is Dag.Arbeidsgiverdag -> JsonDagType.ARBEIDSGIVERDAG
     is Dag.Feriedag -> JsonDagType.FERIEDAG
     is Dag.FriskHelgedag -> JsonDagType.FRISK_HELGEDAG
-    is Dag.ArbeidsgiverHelgedag -> JsonDagType.ARBEIDSGIVER_HELGEDAG
+    is Dag.ArbeidsgiverHelgedag -> JsonDagType.ARBEIDSGIVERDAG
     is Dag.ForeldetSykedag -> JsonDagType.FORELDET_SYKEDAG
-    is Dag.SykHelgedag -> JsonDagType.SYK_HELGEDAG
+    is Dag.SykHelgedag -> JsonDagType.SYKEDAG
     is Dag.Permisjonsdag -> JsonDagType.PERMISJONSDAG
     is Dag.ProblemDag -> JsonDagType.PROBLEMDAG
     is Dag.AvslåttDag -> JsonDagType.AVSLÅTT_DAG

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/reflection/UtbetalingsdagReflect.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/reflection/UtbetalingsdagReflect.kt
@@ -6,28 +6,23 @@ import no.nav.helse.utbetalingstidslinje.Begrunnelse
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje.Utbetalingsdag
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje.Utbetalingsdag.AvvistDag
 import no.nav.helse.økonomi.Økonomi
-import java.time.LocalDate
 
 internal class UtbetalingsdagReflect(utbetalingsdag: Utbetalingsdag, private val type: PersonData.UtbetalingstidslinjeData.TypeData) {
-    private val dato: LocalDate = utbetalingsdag["dato"]
     private val økonomi: Økonomi = utbetalingsdag["økonomi"]
 
     internal fun toMap() = mutableMapOf<String, Any?>(
-        "type" to type,
-        "dato" to dato
+        "type" to type
     ).apply {
         putAll(serialiserØkonomi(økonomi))
     }
 }
 
 internal class AvvistdagReflect(avvistdag: AvvistDag) {
-    private val dato: LocalDate = avvistdag["dato"]
     private val økonomi: Økonomi = avvistdag["økonomi"]
     private val begrunnelser: List<Begrunnelse> = avvistdag["begrunnelser"]
 
     internal fun toMap() = mutableMapOf<String, Any?>(
         "type" to PersonData.UtbetalingstidslinjeData.TypeData.AvvistDag,
-        "dato" to dato,
         "begrunnelser" to begrunnelser.map { PersonData.UtbetalingstidslinjeData.BegrunnelseData.fraBegrunnelse(it).name }
     ).apply {
         putAll(serialiserØkonomi(økonomi))

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/økonomi/CreateØkonomiTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/økonomi/CreateØkonomiTest.kt
@@ -101,7 +101,6 @@ internal class CreateØkonomiTest {
         er6GBegrenset: Boolean = false
     ) = UtbetalingstidslinjeData.UtbetalingsdagData(
         UtbetalingstidslinjeData.TypeData.NavDag,
-        1.januar,
         aktuellDagsinntekt,
         dekningsgrunnlag,
         1.januar,
@@ -125,7 +124,6 @@ internal class CreateØkonomiTest {
         er6GBegrenset: Boolean = false,
         totalGrad: Double? = null
     ) = PersonData.ArbeidsgiverData.SykdomstidslinjeData.DagData(
-        1.januar,
         PersonData.ArbeidsgiverData.SykdomstidslinjeData.JsonDagType.SYKEDAG,
         PersonData.ArbeidsgiverData.SykdomstidslinjeData.KildeData("type", UUID.randomUUID(), LocalDateTime.now()),
         grad,
@@ -142,7 +140,7 @@ internal class CreateØkonomiTest {
 
     private fun createØkonomi(dagData: UtbetalingstidslinjeData.UtbetalingsdagData): Økonomi {
         lateinit var fangetØkonomi: Økonomi
-        dagData.parseDag().accept(object : UtbetalingsdagVisitor {
+        dagData.parseDag(1.januar).accept(object : UtbetalingsdagVisitor {
             override fun visit(
                 dag: Utbetalingstidslinje.Utbetalingsdag.NavDag,
                 dato: LocalDate,
@@ -156,7 +154,7 @@ internal class CreateØkonomiTest {
 
     private fun createØkonomi(dagData: PersonData.ArbeidsgiverData.SykdomstidslinjeData.DagData): Økonomi {
         lateinit var fangetØkonomi: Økonomi
-        dagData.parseDag().accept(object : SykdomstidslinjeVisitor {
+        dagData.parseDag(LocalDate.now()).accept(object : SykdomstidslinjeVisitor {
             override fun visitDag(
                 dag: Dag.Sykedag,
                 dato: LocalDate,


### PR DESCRIPTION
Denne forbedringen tar ned json-størrelsen med 69% til 31% av original størrelse ved et komplisert flere arbeidsgivere case uten infotrygdhistorikk

Mulige forbedringer:
* utbetalingstidslinjer kan slå sammen helg/ikke helg om vi kan ignorere økonomiforskjellen, kan ta ned json størrelsen til 20%
* fjerning av aktivitetsloggen fra json kan ta ned json størrelsen til 23% prosent

Til sammen kan vi ende opp med rundt 10% av original størrelsen.