### PR TITLE
Passer på at vi ikke utvider sykdomstidslinjer med arbeidsdager fremover i tid

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/hendelser/Periode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/hendelser/Periode.kt
@@ -79,6 +79,8 @@ open class Periode(fom: LocalDate, tom: LocalDate) : ClosedRange<LocalDate>, Ite
         override fun next() =
             currentDate.also { currentDate = it.plusDays(1) }
     }
+
+    fun subset(periode: Periode) = Periode(start.coerceAtLeast(periode.start), endInclusive.coerceAtMost(periode.endInclusive))
 }
 
 internal operator fun List<Periode>.contains(dato: LocalDate) = this.any { dato in it }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/Sykdomstidslinje.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/Sykdomstidslinje.kt
@@ -92,15 +92,12 @@ internal class Sykdomstidslinje private constructor(
     internal operator fun plus(other: Sykdomstidslinje) = this.merge(other)
     internal operator fun get(dato: LocalDate): Dag = dager[dato] ?: UkjentDag(dato, INGEN)
     internal fun subset(periode: Periode) =
-        Sykdomstidslinje(dager.filter { it.key in periode }.toSortedMap(), periode)
+        Sykdomstidslinje(dager.filter { it.key in periode }.toSortedMap(), this.periode?.subset(periode))
 
     /**
-     * Without padding of days
+     * Uten å utvide tidslinjen
      */
     internal fun fremTilOgMed(dato: LocalDate) =
-        Sykdomstidslinje(dager.headMap(dato.plusDays(1)).toMap())
-
-    internal fun fremTilOgMed2(dato: LocalDate) =
         if (periode == null || dato < førsteDag()) Sykdomstidslinje() else subset(førsteDag() til dato)
 
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/UtbetalingstidslinjeBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/UtbetalingstidslinjeBuilder.kt
@@ -66,7 +66,7 @@ internal class UtbetalingstidslinjeBuilder internal constructor(
             ?: inntekt(INGEN, skjæringstidspunkt = dato)
 
     override fun result(sykdomstidslinje: Sykdomstidslinje, periode: Periode): Utbetalingstidslinje {
-        sykdomstidslinje.fremTilOgMed2(periode.endInclusive).accept(this)
+        sykdomstidslinje.fremTilOgMed(periode.endInclusive).accept(this)
         hengendeFridager()
         return tidslinje
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/hendelser/PeriodeTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/hendelser/PeriodeTest.kt
@@ -186,6 +186,12 @@ internal class PeriodeTest {
         assertEquals("01-01-2018 til 02-01-2018", Periode(1.januar, 2.januar).toString())
     }
 
+    @Test
+    fun subset() {
+        assertEquals(10.januar til 15.januar, (10.januar til 15.januar).subset(1.januar til 31.januar))
+        assertEquals(11.januar til 12.januar, (10.januar til 15.januar).subset(11.januar til 12.januar))
+    }
+
     private fun assertSize(expected: Int, periode: Periode) {
         var count = 0
         periode.forEach { _ -> count++ }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/PingPongTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/PingPongTest.kt
@@ -8,7 +8,9 @@ import no.nav.helse.person.TilstandType.AVVENTER_GODKJENNING
 import no.nav.helse.person.infotrygdhistorikk.ArbeidsgiverUtbetalingsperiode
 import no.nav.helse.person.infotrygdhistorikk.Inntektsopplysning
 import no.nav.helse.testhelpers.*
+import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
 import no.nav.helse.økonomi.Inntekt.Companion.daglig
+import no.nav.helse.økonomi.Inntekt.Companion.månedlig
 import no.nav.helse.økonomi.Prosentdel.Companion.prosent
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -70,5 +72,23 @@ internal class PingPongTest : AbstractEndToEndTest() {
         håndterUtbetalingsgrunnlag(2.vedtaksperiode)
         håndterYtelser(2.vedtaksperiode)
         assertEquals(1.januar, inspektør.skjæringstidspunkt(2.vedtaksperiode))
+    }
+
+    @Test
+    fun `periode utebetales på nytt orgnummer i IT`() {
+        val a2 = "yep"
+        nyttVedtak(1.januar, 31.januar, 25.prosent)
+
+        håndterSykmelding(Sykmeldingsperiode(1.mars, 31.mars, 25.prosent), orgnummer = a2)
+        håndterSøknad(Sykdom(1.mars, 31.mars, 25.prosent), orgnummer = a2)
+
+        val historikk = ArbeidsgiverUtbetalingsperiode(a2, 1.februar, 28.februar, 25.prosent, INNTEKT)
+        val inntekter = listOf(Inntektsopplysning(a2, 1.februar, 25000.månedlig, true))
+        håndterUtbetalingshistorikk(1.vedtaksperiode(a2), historikk, inntektshistorikk = inntekter, orgnummer = a2)
+        håndterUtbetalingsgrunnlag(1.vedtaksperiode(a2), orgnummer = a2)
+        håndterYtelser(1.vedtaksperiode(a2), orgnummer = a2)
+
+        assertEquals(31, inspektør(ORGNUMMER).utbetalingstidslinjeBeregninger.last().utbetalingstidslinje().size)
+        assertTrue(inspektør(a2).utbetalingstidslinjer(1.vedtaksperiode(a2)).none { it is Utbetalingstidslinje.Utbetalingsdag.AvvistDag })
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/TestArbeidsgiverInspektør.kt
@@ -11,6 +11,7 @@ import no.nav.helse.sykdomstidslinje.Sykdomstidslinje
 import no.nav.helse.sykdomstidslinje.SykdomstidslinjeHendelse.Hendelseskilde
 import no.nav.helse.utbetalingslinjer.*
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
+import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinjeberegning
 import no.nav.helse.økonomi.Økonomi
 import org.junit.jupiter.api.fail
 import java.time.LocalDate
@@ -55,6 +56,7 @@ internal class TestArbeidsgiverInspektør(
     internal val arbeidsgiverOppdrag = mutableListOf<Oppdrag>()
     internal val totalBeløp = mutableListOf<Int>()
     internal val nettoBeløp = mutableListOf<Int>()
+    internal lateinit var utbetalingstidslinjeBeregninger: List<Utbetalingstidslinjeberegning>
     private val utbetalingstidslinjer = mutableMapOf<Int, Utbetalingstidslinje>()
     private val vedtaksperioder = mutableMapOf<Int, Vedtaksperiode>()
     private var forkastetPeriode = false
@@ -89,6 +91,10 @@ internal class TestArbeidsgiverInspektør(
             if (this::arbeidsgiver.isInitialized) return
             this.arbeidsgiver = arbeidsgiver
         }
+    }
+
+    override fun preVisitUtbetalingstidslinjeberegninger(beregninger: List<Utbetalingstidslinjeberegning>) {
+        utbetalingstidslinjeBeregninger = beregninger
     }
 
     override fun preVisitArbeidsgiver(

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/sykdomstidslinje/SimpleMergeTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/sykdomstidslinje/SimpleMergeTest.kt
@@ -54,14 +54,6 @@ internal class SimpleMergeTest {
         Periode(6.januar, 14.januar).also {
             assertEquals(it, original.subset(it).periode())
         }
-
-        Periode(1.februar, 14.februar).also {
-            original.subset(it).also { tidslinje ->
-                assertEquals(it, tidslinje.periode())
-                assertSize(14, tidslinje)
-                assertEquals(14, tidslinje.filterIsInstance<UkjentDag>().size)
-            }
-        }
     }
 
     @Test
@@ -84,8 +76,8 @@ internal class SimpleMergeTest {
         }
 
         original.fremTilOgMed(10.januar).also {
-            assertEquals(Periode(1.januar, 5.januar), it.periode())
-            assertSize(5, it)
+            assertEquals(Periode(1.januar, 10.januar), it.periode())
+            assertSize(10, it)
         }
 
         original.fremTilOgMed(1.februar).also {


### PR DESCRIPTION
Om vi utvider tidslinjen med arbeidsdager fremover i tid vil vi generere en uendelig lang utbetalingstidslinje for arbeidsgivere personen ikke lengre er ansatt i. I ping-pong saker kan dette føre til at en person med en ny arbeidsgiver(nytt orgnummer) vil få utvidet tidslinjen til den gamle arbeidsgiveren og spleis behandle det som et tilfelle av ghosts.