### PR TITLE
Kopierer også låser når vi trimmer et sykdomshistorikkelement

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/Sykdomshistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/Sykdomshistorikk.kt
@@ -134,7 +134,10 @@ internal class Sykdomshistorikk private constructor(
                 historikk: Sykdomshistorikk,
                 periode: Periode
             ) : Element {
-                return Element(beregnetSykdomstidslinje = historikk.sykdomstidslinje().trim(periode))
+                val orginalTidslinje = historikk.sykdomstidslinje()
+                val trimmetTidslinje = orginalTidslinje.trim(periode)
+                    .also { it.kopierLåser(orginalTidslinje) }
+                return Element(beregnetSykdomstidslinje = trimmetTidslinje)
             }
         }
     }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/Sykdomstidslinje.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/sykdomstidslinje/Sykdomstidslinje.kt
@@ -127,6 +127,20 @@ internal class Sykdomstidslinje private constructor(
         låstePerioder.removeIf { it == periode } || throw IllegalArgumentException("Kan ikke låse opp periode $periode")
     }
 
+    internal fun kopierLåser(other: Sykdomstidslinje) {
+        this.låstePerioder.addAll(
+            other.låstePerioder
+                .filter {
+                    // Fjern låste perioder som ligger utenfor vår tidslinje
+                    this.periode?.overlapperMed(it) ?: false
+                }
+                .map {
+                    // Klipp til fom og tom på gjenstående låste perioder
+                    it.subset(maxOf(this.førsteDag(), it.start) til minOf(this.sisteDag(), it.endInclusive))
+                }
+        )
+    }
+
     override operator fun iterator() = object : Iterator<Dag> {
         private val periodeIterator = periode?.iterator()
         override fun hasNext() = periodeIterator?.hasNext() ?: false


### PR DESCRIPTION
Dette fikser det problemet at vi sletter unna låser på avsluttede perioder når vi forkaster etterfølgende. Vi rydder dog ikke opp i eksisterende data (vi sitter igjen med slettede låser)

Men hele låse-greia er ganske awkward. Det er en del implisitte sannheter (som f.eks at låste perioder matcher vedtaksperioder) som ikke ivaretas på noe vis. Revurderinger bryter jo også med litt av poenget med låsene siden vi låser opp og gjør endringer på avsluttede perioder uansett. 

Så jeg lurer på om vi egentlig burde sett på å fjerne konseptet fremfor å fikle med det..?