### PR TITLE
Starten på innkapsling av grunnlagsdata

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -53,9 +53,10 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
-        avviksprosent: Prosent?
+        avviksprosent: Prosent?,
+        antallOpptjeningsdagerErMinst: Int
     ) {
-        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
+        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
     }
 
     override fun postVisitInfotrygdVilkårsgrunnlag(skjæringstidspunkt: LocalDate, infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag) {
@@ -150,9 +151,10 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
-        avviksprosent: Prosent?
+        avviksprosent: Prosent?,
+        antallOpptjeningsdagerErMinst: Int
     ) {
-        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
+        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
     }
 
     override fun preVisitInfotrygdVilkårsgrunnlag(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.person
 
 import no.nav.helse.Fødselsnummer
+import no.nav.helse.hendelser.Medlemskapsvurdering
 import no.nav.helse.hendelser.Periode
 import no.nav.helse.hendelser.Simulering
 import no.nav.helse.person.infotrygdhistorikk.Friperiode
@@ -55,7 +56,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
-        harOpptjening: Boolean
+        harOpptjening: Boolean,
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
     ) {
         delegatee.postVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -64,7 +66,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             sammenligningsgrunnlag,
             avviksprosent,
             antallOpptjeningsdagerErMinst,
-            harOpptjening
+            harOpptjening,
+            medlemskapstatus
         )
     }
 
@@ -162,7 +165,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
-        harOpptjening: Boolean
+        harOpptjening: Boolean,
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
     ) {
         delegatee.preVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -171,7 +175,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             sammenligningsgrunnlag,
             avviksprosent,
             antallOpptjeningsdagerErMinst,
-            harOpptjening
+            harOpptjening,
+            medlemskapstatus
         )
     }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -54,9 +54,18 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
-        antallOpptjeningsdagerErMinst: Int
+        antallOpptjeningsdagerErMinst: Int,
+        harOpptjening: Boolean
     ) {
-        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
+        delegatee.postVisitGrunnlagsdata(
+            skjæringstidspunkt,
+            grunnlagsdata,
+            sykepengegrunnlag,
+            sammenligningsgrunnlag,
+            avviksprosent,
+            antallOpptjeningsdagerErMinst,
+            harOpptjening
+        )
     }
 
     override fun postVisitInfotrygdVilkårsgrunnlag(skjæringstidspunkt: LocalDate, infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag) {
@@ -152,9 +161,18 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
-        antallOpptjeningsdagerErMinst: Int
+        antallOpptjeningsdagerErMinst: Int,
+        harOpptjening: Boolean
     ) {
-        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
+        delegatee.preVisitGrunnlagsdata(
+            skjæringstidspunkt,
+            grunnlagsdata,
+            sykepengegrunnlag,
+            sammenligningsgrunnlag,
+            avviksprosent,
+            antallOpptjeningsdagerErMinst,
+            harOpptjening
+        )
     }
 
     override fun preVisitInfotrygdVilkårsgrunnlag(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -58,7 +58,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {
         delegatee.postVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -69,7 +70,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             antallOpptjeningsdagerErMinst,
             harOpptjening,
             medlemskapstatus,
-            harMinimumInntekt
+            harMinimumInntekt,
+            vurdertOk
         )
     }
 
@@ -169,7 +171,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {
         delegatee.preVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -180,7 +183,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             antallOpptjeningsdagerErMinst,
             harOpptjening,
             medlemskapstatus,
-            harMinimumInntekt
+            harMinimumInntekt,
+            vurdertOk
         )
     }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -50,9 +50,10 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
     override fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
-        sykepengegrunnlag: Sykepengegrunnlag
+        sykepengegrunnlag: Sykepengegrunnlag,
+        sammenligningsgrunnlag: Inntekt
     ) {
-        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag)
+        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag)
     }
 
     override fun postVisitInfotrygdVilkårsgrunnlag(skjæringstidspunkt: LocalDate, infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag) {
@@ -145,9 +146,10 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
     override fun preVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
-        sykepengegrunnlag: Sykepengegrunnlag
+        sykepengegrunnlag: Sykepengegrunnlag,
+        sammenligningsgrunnlag: Inntekt
     ) {
-        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag)
+        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag)
     }
 
     override fun preVisitInfotrygdVilkårsgrunnlag(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -47,8 +47,12 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         delegatee.postVisitUtbetalingstidslinjeberegninger(beregninger)
     }
 
-    override fun postVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
-        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata)
+    override fun postVisitGrunnlagsdata(
+        skjæringstidspunkt: LocalDate,
+        grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+        sykepengegrunnlag: Sykepengegrunnlag
+    ) {
+        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag)
     }
 
     override fun postVisitInfotrygdVilkårsgrunnlag(skjæringstidspunkt: LocalDate, infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag) {
@@ -138,8 +142,12 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         delegatee.preVisitInnslag(innslag, id, opprettet)
     }
 
-    override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
-        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata)
+    override fun preVisitGrunnlagsdata(
+        skjæringstidspunkt: LocalDate,
+        grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+        sykepengegrunnlag: Sykepengegrunnlag
+    ) {
+        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag)
     }
 
     override fun preVisitInfotrygdVilkårsgrunnlag(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -16,6 +16,7 @@ import no.nav.helse.utbetalingstidslinje.Feriepengeberegner
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinjeberegning
 import no.nav.helse.økonomi.Inntekt
+import no.nav.helse.økonomi.Prosent
 import no.nav.helse.økonomi.Prosentdel
 import no.nav.helse.økonomi.Økonomi
 import java.time.LocalDate
@@ -51,9 +52,10 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
-        sammenligningsgrunnlag: Inntekt
+        sammenligningsgrunnlag: Inntekt,
+        avviksprosent: Prosent?
     ) {
-        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag)
+        delegatee.postVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
     }
 
     override fun postVisitInfotrygdVilkårsgrunnlag(skjæringstidspunkt: LocalDate, infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag) {
@@ -147,9 +149,10 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
-        sammenligningsgrunnlag: Inntekt
+        sammenligningsgrunnlag: Inntekt,
+        avviksprosent: Prosent?
     ) {
-        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag)
+        delegatee.preVisitGrunnlagsdata(skjæringstidspunkt, grunnlagsdata, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
     }
 
     override fun preVisitInfotrygdVilkårsgrunnlag(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -59,7 +59,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {
         delegatee.postVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -71,7 +72,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             harOpptjening,
             medlemskapstatus,
             harMinimumInntekt,
-            vurdertOk
+            vurdertOk,
+            meldingsreferanseId
         )
     }
 
@@ -172,7 +174,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {
         delegatee.preVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -184,7 +187,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             harOpptjening,
             medlemskapstatus,
             harMinimumInntekt,
-            vurdertOk
+            vurdertOk,
+            meldingsreferanseId
         )
     }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -57,7 +57,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {
         delegatee.postVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -67,7 +68,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             avviksprosent,
             antallOpptjeningsdagerErMinst,
             harOpptjening,
-            medlemskapstatus
+            medlemskapstatus,
+            harMinimumInntekt
         )
     }
 
@@ -166,7 +168,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {
         delegatee.preVisitGrunnlagsdata(
             skjæringstidspunkt,
@@ -176,7 +179,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             avviksprosent,
             antallOpptjeningsdagerErMinst,
             harOpptjening,
-            medlemskapstatus
+            medlemskapstatus,
+            harMinimumInntekt
         )
     }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -97,7 +97,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
-        antallOpptjeningsdagerErMinst: Int
+        antallOpptjeningsdagerErMinst: Int,
+        harOpptjening: Boolean
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
@@ -105,7 +106,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
-        antallOpptjeningsdagerErMinst: Int
+        antallOpptjeningsdagerErMinst: Int,
+        harOpptjening: Boolean
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -96,14 +96,16 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
-        avviksprosent: Prosent?
+        avviksprosent: Prosent?,
+        antallOpptjeningsdagerErMinst: Int
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
-        avviksprosent: Prosent?
+        avviksprosent: Prosent?,
+        antallOpptjeningsdagerErMinst: Int
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -102,7 +102,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
@@ -114,7 +115,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -90,8 +90,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
     fun preVisitInnslag(innslag: VilkårsgrunnlagHistorikk.Innslag, id: UUID, opprettet: LocalDateTime) {}
     fun postVisitInnslag(innslag: VilkårsgrunnlagHistorikk.Innslag, id: UUID, opprettet: LocalDateTime) {}
     fun postVisitVilkårsgrunnlagHistorikk() {}
-    fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {}
-    fun postVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {}
+    fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata, sykepengegrunnlag: Sykepengegrunnlag) {}
+    fun postVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata, sykepengegrunnlag: Sykepengegrunnlag) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,
         skjæringstidspunkt: LocalDate,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -17,6 +17,7 @@ import no.nav.helse.utbetalingstidslinje.Feriepengeberegner
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinjeberegning
 import no.nav.helse.økonomi.Inntekt
+import no.nav.helse.økonomi.Prosent
 import no.nav.helse.økonomi.Prosentdel
 import no.nav.helse.økonomi.Økonomi
 import java.time.LocalDate
@@ -94,13 +95,15 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
-        sammenligningsgrunnlag: Inntekt
+        sammenligningsgrunnlag: Inntekt,
+        avviksprosent: Prosent?
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
-        sammenligningsgrunnlag: Inntekt
+        sammenligningsgrunnlag: Inntekt,
+        avviksprosent: Prosent?
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -101,7 +101,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
@@ -112,7 +113,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.person
 
 import no.nav.helse.Fødselsnummer
+import no.nav.helse.hendelser.Medlemskapsvurdering
 import no.nav.helse.hendelser.Periode
 import no.nav.helse.hendelser.Simulering
 import no.nav.helse.person.Vedtaksperiode.Vedtaksperiodetilstand
@@ -98,7 +99,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
-        harOpptjening: Boolean
+        harOpptjening: Boolean,
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
@@ -107,7 +109,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
-        harOpptjening: Boolean
+        harOpptjening: Boolean,
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -100,7 +100,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {}
     fun postVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
@@ -110,7 +111,8 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -90,8 +90,18 @@ internal interface VilkårsgrunnlagHistorikkVisitor : InntekthistorikkVisitor {
     fun preVisitInnslag(innslag: VilkårsgrunnlagHistorikk.Innslag, id: UUID, opprettet: LocalDateTime) {}
     fun postVisitInnslag(innslag: VilkårsgrunnlagHistorikk.Innslag, id: UUID, opprettet: LocalDateTime) {}
     fun postVisitVilkårsgrunnlagHistorikk() {}
-    fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata, sykepengegrunnlag: Sykepengegrunnlag) {}
-    fun postVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata, sykepengegrunnlag: Sykepengegrunnlag) {}
+    fun preVisitGrunnlagsdata(
+        skjæringstidspunkt: LocalDate,
+        grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+        sykepengegrunnlag: Sykepengegrunnlag,
+        sammenligningsgrunnlag: Inntekt
+    ) {}
+    fun postVisitGrunnlagsdata(
+        skjæringstidspunkt: LocalDate,
+        grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+        sykepengegrunnlag: Sykepengegrunnlag,
+        sammenligningsgrunnlag: Inntekt
+    ) {}
     fun preVisitInfotrygdVilkårsgrunnlag(
         infotrygdVilkårsgrunnlag: VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag,
         skjæringstidspunkt: LocalDate,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -116,7 +116,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
     internal class Grunnlagsdata(
         private val sykepengegrunnlag: Sykepengegrunnlag,
         private val sammenligningsgrunnlag: Inntekt,
-        internal val avviksprosent: Prosent?,
+        private val avviksprosent: Prosent?,
         internal val antallOpptjeningsdagerErMinst: Int,
         internal val harOpptjening: Boolean,
         internal val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
@@ -144,9 +144,9 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         override fun isOk() = vurdertOk
 
         override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {
-            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag)
+            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt,this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
-            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag)
+            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt,this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
         }
 
         override fun sykepengegrunnlag() = sykepengegrunnlag.sykepengegrunnlag

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -111,7 +111,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         private val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         private val harMinimumInntekt: Boolean?,
         private val vurdertOk: Boolean,
-        internal val meldingsreferanseId: UUID?
+        private val meldingsreferanseId: UUID?
     ) : VilkårsgrunnlagElement {
         private companion object {
             private val sikkerLogg = LoggerFactory.getLogger("tjenestekall")
@@ -143,7 +143,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 harOpptjening,
                 medlemskapstatus,
                 harMinimumInntekt,
-                vurdertOk
+                vurdertOk,
+                meldingsreferanseId
             )
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
             vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(
@@ -156,7 +157,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 harOpptjening,
                 medlemskapstatus,
                 harMinimumInntekt,
-                vurdertOk
+                vurdertOk,
+                meldingsreferanseId
             )
         }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -114,7 +114,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
     }
 
     internal class Grunnlagsdata(
-        internal val sykepengegrunnlag: Sykepengegrunnlag,
+        private val sykepengegrunnlag: Sykepengegrunnlag,
         internal val sammenligningsgrunnlag: Inntekt,
         internal val avviksprosent: Prosent?,
         internal val antallOpptjeningsdagerErMinst: Int,
@@ -144,9 +144,9 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         override fun isOk() = vurdertOk
 
         override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {
-            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this)
+            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag)
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
-            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this)
+            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag)
         }
 
         override fun sykepengegrunnlag() = sykepengegrunnlag.sykepengegrunnlag

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -109,7 +109,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         private val antallOpptjeningsdagerErMinst: Int,
         private val harOpptjening: Boolean,
         private val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        internal val harMinimumInntekt: Boolean?,
+        private val harMinimumInntekt: Boolean?,
         internal val vurdertOk: Boolean,
         internal val meldingsreferanseId: UUID?
     ) : VilkårsgrunnlagElement {
@@ -141,7 +141,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 avviksprosent,
                 antallOpptjeningsdagerErMinst,
                 harOpptjening,
-                medlemskapstatus
+                medlemskapstatus,
+                harMinimumInntekt
             )
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
             vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(
@@ -152,7 +153,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 avviksprosent,
                 antallOpptjeningsdagerErMinst,
                 harOpptjening,
-                medlemskapstatus
+                medlemskapstatus,
+                harMinimumInntekt
             )
         }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -107,7 +107,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         private val sammenligningsgrunnlag: Inntekt,
         private val avviksprosent: Prosent?,
         private val antallOpptjeningsdagerErMinst: Int,
-        internal val harOpptjening: Boolean,
+        private val harOpptjening: Boolean,
         internal val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         internal val harMinimumInntekt: Boolean?,
         internal val vurdertOk: Boolean,
@@ -133,9 +133,25 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         override fun isOk() = vurdertOk
 
         override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {
-            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
+            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(
+                skjæringstidspunkt,
+                this,
+                sykepengegrunnlag,
+                sammenligningsgrunnlag,
+                avviksprosent,
+                antallOpptjeningsdagerErMinst,
+                harOpptjening
+            )
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
-            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
+            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(
+                skjæringstidspunkt,
+                this,
+                sykepengegrunnlag,
+                sammenligningsgrunnlag,
+                avviksprosent,
+                antallOpptjeningsdagerErMinst,
+                harOpptjening
+            )
         }
 
         override fun sykepengegrunnlag() = sykepengegrunnlag.sykepengegrunnlag

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -115,7 +115,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
 
     internal class Grunnlagsdata(
         private val sykepengegrunnlag: Sykepengegrunnlag,
-        internal val sammenligningsgrunnlag: Inntekt,
+        private val sammenligningsgrunnlag: Inntekt,
         internal val avviksprosent: Prosent?,
         internal val antallOpptjeningsdagerErMinst: Int,
         internal val harOpptjening: Boolean,
@@ -144,9 +144,9 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         override fun isOk() = vurdertOk
 
         override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {
-            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag)
+            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag)
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
-            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag)
+            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag)
         }
 
         override fun sykepengegrunnlag() = sykepengegrunnlag.sykepengegrunnlag

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -110,7 +110,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         private val harOpptjening: Boolean,
         private val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         private val harMinimumInntekt: Boolean?,
-        internal val vurdertOk: Boolean,
+        private val vurdertOk: Boolean,
         internal val meldingsreferanseId: UUID?
     ) : VilkårsgrunnlagElement {
         private companion object {
@@ -142,7 +142,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 antallOpptjeningsdagerErMinst,
                 harOpptjening,
                 medlemskapstatus,
-                harMinimumInntekt
+                harMinimumInntekt,
+                vurdertOk
             )
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
             vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(
@@ -154,7 +155,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 antallOpptjeningsdagerErMinst,
                 harOpptjening,
                 medlemskapstatus,
-                harMinimumInntekt
+                harMinimumInntekt,
+                vurdertOk
             )
         }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -117,7 +117,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         private val sykepengegrunnlag: Sykepengegrunnlag,
         private val sammenligningsgrunnlag: Inntekt,
         private val avviksprosent: Prosent?,
-        internal val antallOpptjeningsdagerErMinst: Int,
+        private val antallOpptjeningsdagerErMinst: Int,
         internal val harOpptjening: Boolean,
         internal val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         internal val harMinimumInntekt: Boolean?,
@@ -144,9 +144,9 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         override fun isOk() = vurdertOk
 
         override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {
-            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt,this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
+            vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
-            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt,this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent)
+            vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(skjæringstidspunkt, this, sykepengegrunnlag, sammenligningsgrunnlag, avviksprosent, antallOpptjeningsdagerErMinst)
         }
 
         override fun sykepengegrunnlag() = sykepengegrunnlag.sykepengegrunnlag

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -108,7 +108,7 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         private val avviksprosent: Prosent?,
         private val antallOpptjeningsdagerErMinst: Int,
         private val harOpptjening: Boolean,
-        internal val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        private val medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         internal val harMinimumInntekt: Boolean?,
         internal val vurdertOk: Boolean,
         internal val meldingsreferanseId: UUID?
@@ -140,7 +140,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 sammenligningsgrunnlag,
                 avviksprosent,
                 antallOpptjeningsdagerErMinst,
-                harOpptjening
+                harOpptjening,
+                medlemskapstatus
             )
             sykepengegrunnlag.accept(vilkårsgrunnlagHistorikkVisitor)
             vilkårsgrunnlagHistorikkVisitor.postVisitGrunnlagsdata(
@@ -150,7 +151,8 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
                 sammenligningsgrunnlag,
                 avviksprosent,
                 antallOpptjeningsdagerErMinst,
-                harOpptjening
+                harOpptjening,
+                medlemskapstatus
             )
         }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -604,7 +604,8 @@ internal class JsonBuilder : AbstractBuilder() {
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
-            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+            harMinimumInntekt: Boolean?
         ) {
             val sykepengegrunnlagMap = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
@@ -621,7 +622,7 @@ internal class JsonBuilder : AbstractBuilder() {
                         Medlemskapsvurdering.Medlemskapstatus.Nei -> JsonMedlemskapstatus.NEI
                         Medlemskapsvurdering.Medlemskapstatus.VetIkke -> JsonMedlemskapstatus.VET_IKKE
                     },
-                    "harMinimumInntekt" to grunnlagsdata.harMinimumInntekt,
+                    "harMinimumInntekt" to harMinimumInntekt,
                     "vurdertOk" to grunnlagsdata.vurdertOk,
                     "meldingsreferanseId" to grunnlagsdata.meldingsreferanseId
                 )
@@ -682,7 +683,8 @@ internal class JsonBuilder : AbstractBuilder() {
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
-            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+            harMinimumInntekt: Boolean?
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -21,6 +21,7 @@ import no.nav.helse.utbetalingslinjer.*
 import no.nav.helse.utbetalingstidslinje.Feriepengeberegner
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
 import no.nav.helse.økonomi.Inntekt
+import no.nav.helse.økonomi.Prosent
 import no.nav.helse.økonomi.Prosentdel
 import no.nav.helse.økonomi.Økonomi
 import java.time.LocalDate
@@ -599,7 +600,8 @@ internal class JsonBuilder : AbstractBuilder() {
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
-            sammenligningsgrunnlag: Inntekt
+            sammenligningsgrunnlag: Inntekt,
+            avviksprosent: Prosent?
         ) {
             val sykepengegrunnlag = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
@@ -607,7 +609,7 @@ internal class JsonBuilder : AbstractBuilder() {
                     "skjæringstidspunkt" to skjæringstidspunkt,
                     "type" to "Vilkårsprøving",
                     "antallOpptjeningsdagerErMinst" to grunnlagsdata.antallOpptjeningsdagerErMinst,
-                    "avviksprosent" to grunnlagsdata.avviksprosent?.ratio(),
+                    "avviksprosent" to avviksprosent?.ratio(),
                     "sykepengegrunnlag" to sykepengegrunnlag,
                     "sammenligningsgrunnlag" to sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
                     "harOpptjening" to grunnlagsdata.harOpptjening,
@@ -673,7 +675,8 @@ internal class JsonBuilder : AbstractBuilder() {
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
-            sammenligningsgrunnlag: Inntekt
+            sammenligningsgrunnlag: Inntekt,
+            avviksprosent: Prosent?
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -602,18 +602,19 @@ internal class JsonBuilder : AbstractBuilder() {
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
-            antallOpptjeningsdagerErMinst: Int
+            antallOpptjeningsdagerErMinst: Int,
+            harOpptjening: Boolean
         ) {
-            val sykepengegrunnlag = mutableMapOf<String, Any>()
+            val sykepengegrunnlagMap = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
                 mapOf(
                     "skjæringstidspunkt" to skjæringstidspunkt,
                     "type" to "Vilkårsprøving",
                     "antallOpptjeningsdagerErMinst" to antallOpptjeningsdagerErMinst,
                     "avviksprosent" to avviksprosent?.ratio(),
-                    "sykepengegrunnlag" to sykepengegrunnlag,
+                    "sykepengegrunnlag" to sykepengegrunnlagMap,
                     "sammenligningsgrunnlag" to sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
-                    "harOpptjening" to grunnlagsdata.harOpptjening,
+                    "harOpptjening" to harOpptjening,
                     "medlemskapstatus" to when (grunnlagsdata.medlemskapstatus) {
                         Medlemskapsvurdering.Medlemskapstatus.Ja -> JsonMedlemskapstatus.JA
                         Medlemskapsvurdering.Medlemskapstatus.Nei -> JsonMedlemskapstatus.NEI
@@ -625,7 +626,7 @@ internal class JsonBuilder : AbstractBuilder() {
                 )
             )
 
-            pushState(SykepengegrunnlagState(sykepengegrunnlag))
+            pushState(SykepengegrunnlagState(sykepengegrunnlagMap))
         }
 
         override fun preVisitInfotrygdVilkårsgrunnlag(
@@ -633,16 +634,16 @@ internal class JsonBuilder : AbstractBuilder() {
             skjæringstidspunkt: LocalDate,
             sykepengegrunnlag: Sykepengegrunnlag
         ) {
-            val sykepengegrunnlag = mutableMapOf<String, Any>()
+            val sykepengegrunnlagMap = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
                 mapOf(
                     "skjæringstidspunkt" to skjæringstidspunkt,
                     "type" to "Infotrygd",
-                    "sykepengegrunnlag" to sykepengegrunnlag
+                    "sykepengegrunnlag" to sykepengegrunnlagMap
                 )
             )
 
-            pushState(SykepengegrunnlagState(sykepengegrunnlag))
+            pushState(SykepengegrunnlagState(sykepengegrunnlagMap))
         }
 
 
@@ -678,7 +679,8 @@ internal class JsonBuilder : AbstractBuilder() {
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
-            antallOpptjeningsdagerErMinst: Int
+            antallOpptjeningsdagerErMinst: Int,
+            harOpptjening: Boolean
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -595,7 +595,11 @@ internal class JsonBuilder : AbstractBuilder() {
 
     private class VilkårsgrunnlagElementState(private val vilkårsgrunnlagElement: MutableList<Map<String, Any?>>) : BuilderState() {
 
-        override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
+        override fun preVisitGrunnlagsdata(
+            skjæringstidspunkt: LocalDate,
+            grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+            sykepengegrunnlag: Sykepengegrunnlag
+        ) {
             val sykepengegrunnlag = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
                 mapOf(
@@ -664,7 +668,11 @@ internal class JsonBuilder : AbstractBuilder() {
             pushState(ArbeidsgiverInntektsopplysningerState(arbeidsgiverInntektsopplysninger))
         }
 
-        override fun postVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
+        override fun postVisitGrunnlagsdata(
+            skjæringstidspunkt: LocalDate,
+            grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+            sykepengegrunnlag: Sykepengegrunnlag
+        ) {
             popState()
         }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -598,7 +598,8 @@ internal class JsonBuilder : AbstractBuilder() {
         override fun preVisitGrunnlagsdata(
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
-            sykepengegrunnlag: Sykepengegrunnlag
+            sykepengegrunnlag: Sykepengegrunnlag,
+            sammenligningsgrunnlag: Inntekt
         ) {
             val sykepengegrunnlag = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
@@ -608,7 +609,7 @@ internal class JsonBuilder : AbstractBuilder() {
                     "antallOpptjeningsdagerErMinst" to grunnlagsdata.antallOpptjeningsdagerErMinst,
                     "avviksprosent" to grunnlagsdata.avviksprosent?.ratio(),
                     "sykepengegrunnlag" to sykepengegrunnlag,
-                    "sammenligningsgrunnlag" to grunnlagsdata.sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
+                    "sammenligningsgrunnlag" to sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
                     "harOpptjening" to grunnlagsdata.harOpptjening,
                     "medlemskapstatus" to when (grunnlagsdata.medlemskapstatus) {
                         Medlemskapsvurdering.Medlemskapstatus.Ja -> JsonMedlemskapstatus.JA
@@ -671,7 +672,8 @@ internal class JsonBuilder : AbstractBuilder() {
         override fun postVisitGrunnlagsdata(
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
-            sykepengegrunnlag: Sykepengegrunnlag
+            sykepengegrunnlag: Sykepengegrunnlag,
+            sammenligningsgrunnlag: Inntekt
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -603,7 +603,8 @@ internal class JsonBuilder : AbstractBuilder() {
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
-            harOpptjening: Boolean
+            harOpptjening: Boolean,
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
         ) {
             val sykepengegrunnlagMap = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
@@ -615,7 +616,7 @@ internal class JsonBuilder : AbstractBuilder() {
                     "sykepengegrunnlag" to sykepengegrunnlagMap,
                     "sammenligningsgrunnlag" to sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
                     "harOpptjening" to harOpptjening,
-                    "medlemskapstatus" to when (grunnlagsdata.medlemskapstatus) {
+                    "medlemskapstatus" to when (medlemskapstatus) {
                         Medlemskapsvurdering.Medlemskapstatus.Ja -> JsonMedlemskapstatus.JA
                         Medlemskapsvurdering.Medlemskapstatus.Nei -> JsonMedlemskapstatus.NEI
                         Medlemskapsvurdering.Medlemskapstatus.VetIkke -> JsonMedlemskapstatus.VET_IKKE
@@ -680,7 +681,8 @@ internal class JsonBuilder : AbstractBuilder() {
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
-            harOpptjening: Boolean
+            harOpptjening: Boolean,
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -606,7 +606,8 @@ internal class JsonBuilder : AbstractBuilder() {
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
             harMinimumInntekt: Boolean?,
-            vurdertOk: Boolean
+            vurdertOk: Boolean,
+            meldingsreferanseId: UUID?
         ) {
             val sykepengegrunnlagMap = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
@@ -625,7 +626,7 @@ internal class JsonBuilder : AbstractBuilder() {
                     },
                     "harMinimumInntekt" to harMinimumInntekt,
                     "vurdertOk" to vurdertOk,
-                    "meldingsreferanseId" to grunnlagsdata.meldingsreferanseId
+                    "meldingsreferanseId" to meldingsreferanseId
                 )
             )
 
@@ -686,7 +687,8 @@ internal class JsonBuilder : AbstractBuilder() {
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
             harMinimumInntekt: Boolean?,
-            vurdertOk: Boolean
+            vurdertOk: Boolean,
+            meldingsreferanseId: UUID?
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -601,14 +601,15 @@ internal class JsonBuilder : AbstractBuilder() {
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
-            avviksprosent: Prosent?
+            avviksprosent: Prosent?,
+            antallOpptjeningsdagerErMinst: Int
         ) {
             val sykepengegrunnlag = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
                 mapOf(
                     "skjæringstidspunkt" to skjæringstidspunkt,
                     "type" to "Vilkårsprøving",
-                    "antallOpptjeningsdagerErMinst" to grunnlagsdata.antallOpptjeningsdagerErMinst,
+                    "antallOpptjeningsdagerErMinst" to antallOpptjeningsdagerErMinst,
                     "avviksprosent" to avviksprosent?.ratio(),
                     "sykepengegrunnlag" to sykepengegrunnlag,
                     "sammenligningsgrunnlag" to sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
@@ -676,7 +677,8 @@ internal class JsonBuilder : AbstractBuilder() {
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
-            avviksprosent: Prosent?
+            avviksprosent: Prosent?,
+            antallOpptjeningsdagerErMinst: Int
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -605,7 +605,8 @@ internal class JsonBuilder : AbstractBuilder() {
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-            harMinimumInntekt: Boolean?
+            harMinimumInntekt: Boolean?,
+            vurdertOk: Boolean
         ) {
             val sykepengegrunnlagMap = mutableMapOf<String, Any>()
             vilkårsgrunnlagElement.add(
@@ -623,7 +624,7 @@ internal class JsonBuilder : AbstractBuilder() {
                         Medlemskapsvurdering.Medlemskapstatus.VetIkke -> JsonMedlemskapstatus.VET_IKKE
                     },
                     "harMinimumInntekt" to harMinimumInntekt,
-                    "vurdertOk" to grunnlagsdata.vurdertOk,
+                    "vurdertOk" to vurdertOk,
                     "meldingsreferanseId" to grunnlagsdata.meldingsreferanseId
                 )
             )
@@ -684,7 +685,8 @@ internal class JsonBuilder : AbstractBuilder() {
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-            harMinimumInntekt: Boolean?
+            harMinimumInntekt: Boolean?,
+            vurdertOk: Boolean
         ) {
             popState()
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
@@ -72,15 +72,19 @@ internal class VedtaksperiodeBuilder(
             private set
         var avviksprosent: Prosent? = null
             private set
+        var antallOpptjeningsdagerErMinst: Int = 0
+            private set
         override fun preVisitGrunnlagsdata(
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
-            avviksprosent: Prosent?
+            avviksprosent: Prosent?,
+            antallOpptjeningsdagerErMinst: Int
         ) {
             this.sammenligningsgrunnlag = sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig }
             this.avviksprosent = avviksprosent
+            this.antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst
         }
     }
 
@@ -89,15 +93,16 @@ internal class VedtaksperiodeBuilder(
         GrunnlagsdataDTO(
             beregnetÅrsinntektFraInntektskomponenten = builder.sammenligningsgrunnlag,
             avviksprosent = builder.avviksprosent?.ratio(),
-            antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst,
+            antallOpptjeningsdagerErMinst = builder.antallOpptjeningsdagerErMinst,
             harOpptjening = grunnlagsdata.harOpptjening,
             medlemskapstatus = medlemskapstatusDTO!!
         )
     }
     private val opptjeningDTO: OpptjeningDTO? = dataForVilkårsvurdering?.let { grunnlagsdata ->
+        val builder = GrunnlagsdataBuilder(grunnlagsdata)
         OpptjeningDTO(
-            antallKjenteOpptjeningsdager = grunnlagsdata.antallOpptjeningsdagerErMinst,
-            fom = skjæringstidspunkt.minusDays(grunnlagsdata.antallOpptjeningsdagerErMinst.toLong()),
+            antallKjenteOpptjeningsdager = builder.antallOpptjeningsdagerErMinst,
+            fom = skjæringstidspunkt.minusDays(builder.antallOpptjeningsdagerErMinst.toLong()),
             oppfylt = grunnlagsdata.harOpptjening
         )
     }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
@@ -487,7 +487,8 @@ private class GrunnlagsdataBuilder(skjæringstidspunkt: LocalDate, grunnlagsdata
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {
         this.medlemskapstatus = when (medlemskapstatus) {
             Medlemskapsvurdering.Medlemskapstatus.Ja -> MedlemskapstatusDTO.JA

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
@@ -63,9 +63,26 @@ internal class VedtaksperiodeBuilder(
         }
     }
 
+    private class GrunnlagsdataBuilder(grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) : VilkårsgrunnlagHistorikkVisitor {
+        init {
+            grunnlagsdata.accept(LocalDate.now(), this)
+        }
+        var sammenligningsgrunnlag: Double = 0.0
+            private set
+        override fun preVisitGrunnlagsdata(
+            skjæringstidspunkt: LocalDate,
+            grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+            sykepengegrunnlag: Sykepengegrunnlag,
+            sammenligningsgrunnlag: Inntekt
+        ) {
+            this.sammenligningsgrunnlag = sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig }
+        }
+    }
+
     private val dataForVilkårsvurdering: GrunnlagsdataDTO? = dataForVilkårsvurdering?.let { grunnlagsdata ->
+        val builder = GrunnlagsdataBuilder(grunnlagsdata)
         GrunnlagsdataDTO(
-            beregnetÅrsinntektFraInntektskomponenten = grunnlagsdata.sammenligningsgrunnlag.reflection { årlig, _, _, _ -> årlig },
+            beregnetÅrsinntektFraInntektskomponenten = builder.sammenligningsgrunnlag,
             avviksprosent = grunnlagsdata.avviksprosent?.ratio(),
             antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst,
             harOpptjening = grunnlagsdata.harOpptjening,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
@@ -488,7 +488,8 @@ private class GrunnlagsdataBuilder(skjæringstidspunkt: LocalDate, grunnlagsdata
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {
         this.medlemskapstatus = when (medlemskapstatus) {
             Medlemskapsvurdering.Medlemskapstatus.Ja -> MedlemskapstatusDTO.JA

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/VedtaksperiodeBuilder.kt
@@ -51,12 +51,13 @@ internal class VedtaksperiodeBuilder(
             TilstandType.AVVENTER_ARBEIDSGIVERE_REVURDERING,
             TilstandType.AVVENTER_GJENNOMFØRT_REVURDERING
         ) || (tilstand.type == TilstandType.AVSLUTTET_UTEN_UTBETALING && beregningIder.isNotEmpty())
-    private val warnings =
-        (hentWarnings(vedtaksperiode) + (dataForVilkårsvurdering?.meldingsreferanseId?.let { hentVilkårsgrunnlagWarnings(vedtaksperiode, id, it) }
-            ?: emptyList())).distinctBy { it.melding }
-    private val beregnetSykdomstidslinje = mutableListOf<SykdomstidslinjedagDTO>()
-
     private val grunnlagsdataBuilder = dataForVilkårsvurdering?.let { GrunnlagsdataBuilder(skjæringstidspunkt, it) }
+
+    private val warnings =
+        (hentWarnings(vedtaksperiode) + (grunnlagsdataBuilder?.meldingsreferanseId?.let { hentVilkårsgrunnlagWarnings(vedtaksperiode, id, it) }
+            ?: emptyList())).distinctBy { it.melding }
+
+    private val beregnetSykdomstidslinje = mutableListOf<SykdomstidslinjedagDTO>()
 
     private var dataForSimulering: SimuleringsdataDTO? = null
     private var arbeidsgiverFagsystemId: String? = null
@@ -478,6 +479,8 @@ private class GrunnlagsdataBuilder(skjæringstidspunkt: LocalDate, grunnlagsdata
         private set
     var avviksprosent: Double? = null
         private set
+    var meldingsreferanseId: UUID? = null
+        private set
 
     override fun preVisitGrunnlagsdata(
         skjæringstidspunkt: LocalDate,
@@ -489,7 +492,8 @@ private class GrunnlagsdataBuilder(skjæringstidspunkt: LocalDate, grunnlagsdata
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {
         this.medlemskapstatus = when (medlemskapstatus) {
             Medlemskapsvurdering.Medlemskapstatus.Ja -> MedlemskapstatusDTO.JA
@@ -509,6 +513,7 @@ private class GrunnlagsdataBuilder(skjæringstidspunkt: LocalDate, grunnlagsdata
             oppfylt = harOpptjening
         )
         this.avviksprosent = avviksprosent?.prosent()
+        this.meldingsreferanseId = meldingsreferanseId
     }
 }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -156,7 +156,8 @@ internal class VilkårsgrunnlagBuilder(
             grunnlagsdata: Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
-            avviksprosent: Prosent?
+            avviksprosent: Prosent?,
+            antallOpptjeningsdagerErMinst: Int
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
@@ -177,7 +178,7 @@ internal class VilkårsgrunnlagBuilder(
                     avviksprosent = avviksprosent?.prosent(),
                     grunnbeløp = grunnbeløp.årlig.toInt(),
                     meldingsreferanseId = grunnlagsdata.meldingsreferanseId,
-                    antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst,
+                    antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst,
                     oppfyllerKravOmMinstelønn = compositeSykepengegrunnlag.sykepengegrunnlag > minimumInntekt.årlig,
                     oppfyllerKravOmOpptjening = grunnlagsdata.harOpptjening,
                     oppfyllerKravOmMedlemskap = oppfyllerKravOmMedlemskap

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -161,7 +161,8 @@ internal class VilkårsgrunnlagBuilder(
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
             harMinimumInntekt: Boolean?,
-            vurdertOk: Boolean
+            vurdertOk: Boolean,
+            meldingsreferanseId: UUID?
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
@@ -181,7 +182,7 @@ internal class VilkårsgrunnlagBuilder(
                     sykepengegrunnlag = compositeSykepengegrunnlag.sykepengegrunnlag,
                     avviksprosent = avviksprosent?.prosent(),
                     grunnbeløp = grunnbeløp.årlig.toInt(),
-                    meldingsreferanseId = grunnlagsdata.meldingsreferanseId,
+                    meldingsreferanseId = meldingsreferanseId,
                     antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst,
                     oppfyllerKravOmMinstelønn = compositeSykepengegrunnlag.sykepengegrunnlag > minimumInntekt.årlig,
                     oppfyllerKravOmOpptjening = harOpptjening,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -159,7 +159,8 @@ internal class VilkårsgrunnlagBuilder(
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
-            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+            harMinimumInntekt: Boolean?
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -9,6 +9,7 @@ import no.nav.helse.person.VilkårsgrunnlagHistorikk.InfotrygdVilkårsgrunnlag
 import no.nav.helse.serde.api.v2.SpleisVilkårsgrunnlag
 import no.nav.helse.serde.api.v2.Vilkårsgrunnlag
 import no.nav.helse.økonomi.Inntekt
+import no.nav.helse.økonomi.Prosent
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -154,12 +155,12 @@ internal class VilkårsgrunnlagBuilder(
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
-            sammenligningsgrunnlag: Inntekt
+            sammenligningsgrunnlag: Inntekt,
+            avviksprosent: Prosent?
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
             val grunnbeløp = InntektBuilder(Grunnbeløp.`1G`.beløp(skjæringstidspunkt)).build()
-            val avviksprosent = grunnlagsdata.avviksprosent?.prosent()
             val oppfyllerKravOmMedlemskap = when (grunnlagsdata.medlemskapstatus) {
                 Medlemskapsvurdering.Medlemskapstatus.Ja -> true
                 Medlemskapsvurdering.Medlemskapstatus.Nei -> false
@@ -173,7 +174,7 @@ internal class VilkårsgrunnlagBuilder(
                     sammenligningsgrunnlag = InntektBuilder(sammenligningsgrunnlag).build().årlig,
                     inntekter = compositeSykepengegrunnlag.inntekterPerArbeidsgiver,
                     sykepengegrunnlag = compositeSykepengegrunnlag.sykepengegrunnlag,
-                    avviksprosent = avviksprosent,
+                    avviksprosent = avviksprosent?.prosent(),
                     grunnbeløp = grunnbeløp.årlig.toInt(),
                     meldingsreferanseId = grunnlagsdata.meldingsreferanseId,
                     antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -158,12 +158,13 @@ internal class VilkårsgrunnlagBuilder(
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
-            harOpptjening: Boolean
+            harOpptjening: Boolean,
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
             val grunnbeløp = InntektBuilder(Grunnbeløp.`1G`.beløp(skjæringstidspunkt)).build()
-            val oppfyllerKravOmMedlemskap = when (grunnlagsdata.medlemskapstatus) {
+            val oppfyllerKravOmMedlemskap = when (medlemskapstatus) {
                 Medlemskapsvurdering.Medlemskapstatus.Ja -> true
                 Medlemskapsvurdering.Medlemskapstatus.Nei -> false
                 else -> null

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -150,10 +150,14 @@ internal class VilkårsgrunnlagBuilder(
 
         internal fun build() = IInnslag(vilkårsgrunnlag.toMap())
 
-        override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: Grunnlagsdata, sykepengegrunnlag: Sykepengegrunnlag) {
+        override fun preVisitGrunnlagsdata(
+            skjæringstidspunkt: LocalDate,
+            grunnlagsdata: Grunnlagsdata,
+            sykepengegrunnlag: Sykepengegrunnlag,
+            sammenligningsgrunnlag: Inntekt
+        ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
-            val sammenligningsgrunnlag = InntektBuilder(grunnlagsdata.sammenligningsgrunnlag).build()
             val grunnbeløp = InntektBuilder(Grunnbeløp.`1G`.beløp(skjæringstidspunkt)).build()
             val avviksprosent = grunnlagsdata.avviksprosent?.prosent()
             val oppfyllerKravOmMedlemskap = when (grunnlagsdata.medlemskapstatus) {
@@ -166,7 +170,7 @@ internal class VilkårsgrunnlagBuilder(
                 skjæringstidspunkt, ISpleisGrunnlag(
                     skjæringstidspunkt = skjæringstidspunkt,
                     omregnetÅrsinntekt = compositeSykepengegrunnlag.omregnetÅrsinntekt,
-                    sammenligningsgrunnlag = sammenligningsgrunnlag.årlig,
+                    sammenligningsgrunnlag = InntektBuilder(sammenligningsgrunnlag).build().årlig,
                     inntekter = compositeSykepengegrunnlag.inntekterPerArbeidsgiver,
                     sykepengegrunnlag = compositeSykepengegrunnlag.sykepengegrunnlag,
                     avviksprosent = avviksprosent,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -150,8 +150,8 @@ internal class VilkårsgrunnlagBuilder(
 
         internal fun build() = IInnslag(vilkårsgrunnlag.toMap())
 
-        override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: Grunnlagsdata) {
-            val sykepengegrunnlag = SykepengegrunnlagBuilder(grunnlagsdata.sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
+        override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: Grunnlagsdata, sykepengegrunnlag: Sykepengegrunnlag) {
+            val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
             val sammenligningsgrunnlag = InntektBuilder(grunnlagsdata.sammenligningsgrunnlag).build()
             val grunnbeløp = InntektBuilder(Grunnbeløp.`1G`.beløp(skjæringstidspunkt)).build()
@@ -165,15 +165,15 @@ internal class VilkårsgrunnlagBuilder(
             vilkårsgrunnlag.putIfAbsent(
                 skjæringstidspunkt, ISpleisGrunnlag(
                     skjæringstidspunkt = skjæringstidspunkt,
-                    omregnetÅrsinntekt = sykepengegrunnlag.omregnetÅrsinntekt,
+                    omregnetÅrsinntekt = compositeSykepengegrunnlag.omregnetÅrsinntekt,
                     sammenligningsgrunnlag = sammenligningsgrunnlag.årlig,
-                    inntekter = sykepengegrunnlag.inntekterPerArbeidsgiver,
-                    sykepengegrunnlag = sykepengegrunnlag.sykepengegrunnlag,
+                    inntekter = compositeSykepengegrunnlag.inntekterPerArbeidsgiver,
+                    sykepengegrunnlag = compositeSykepengegrunnlag.sykepengegrunnlag,
                     avviksprosent = avviksprosent,
                     grunnbeløp = grunnbeløp.årlig.toInt(),
                     meldingsreferanseId = grunnlagsdata.meldingsreferanseId,
                     antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst,
-                    oppfyllerKravOmMinstelønn = sykepengegrunnlag.sykepengegrunnlag > minimumInntekt.årlig,
+                    oppfyllerKravOmMinstelønn = compositeSykepengegrunnlag.sykepengegrunnlag > minimumInntekt.årlig,
                     oppfyllerKravOmOpptjening = grunnlagsdata.harOpptjening,
                     oppfyllerKravOmMedlemskap = oppfyllerKravOmMedlemskap
                 )

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -157,7 +157,8 @@ internal class VilkårsgrunnlagBuilder(
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
-            antallOpptjeningsdagerErMinst: Int
+            antallOpptjeningsdagerErMinst: Int,
+            harOpptjening: Boolean
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()
@@ -180,7 +181,7 @@ internal class VilkårsgrunnlagBuilder(
                     meldingsreferanseId = grunnlagsdata.meldingsreferanseId,
                     antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst,
                     oppfyllerKravOmMinstelønn = compositeSykepengegrunnlag.sykepengegrunnlag > minimumInntekt.årlig,
-                    oppfyllerKravOmOpptjening = grunnlagsdata.harOpptjening,
+                    oppfyllerKravOmOpptjening = harOpptjening,
                     oppfyllerKravOmMedlemskap = oppfyllerKravOmMedlemskap
                 )
             )

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilder.kt
@@ -160,7 +160,8 @@ internal class VilkårsgrunnlagBuilder(
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-            harMinimumInntekt: Boolean?
+            harMinimumInntekt: Boolean?,
+            vurdertOk: Boolean
         ) {
             val compositeSykepengegrunnlag = SykepengegrunnlagBuilder(sykepengegrunnlag, sammenligningsgrunnlagBuilder).build()
             val minimumInntekt = InntektBuilder(person.minimumInntekt(skjæringstidspunkt)).build()

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Alder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Alder.kt
@@ -34,7 +34,11 @@ internal class Alder(fødselsnummer: Fødselsnummer) {
 
     internal fun minimumInntekt(dato: LocalDate) = (if (forhøyetInntektskrav(dato)) Grunnbeløp.`2G` else Grunnbeløp.halvG).beløp(dato)
 
+    // Forhøyet inntektskrav gjelder fra dagen _etter_ 67-årsdagen - se §8-51 andre ledd der det spesifiseres _mellom_.
     internal fun forhøyetInntektskrav(dato: LocalDate) = dato > forhøyetInntektskravAlder
+
+    internal fun begrunnelseForMinimumInntekt(skjæringstidspunkt: LocalDate) =
+        if (forhøyetInntektskrav(skjæringstidspunkt)) Begrunnelse.MinimumInntektOver67 else Begrunnelse.MinimumInntekt
 
     internal fun beregnFeriepenger(opptjeningsår: Year, beløp: Int): Double {
         val alderVedSluttenAvÅret = alderVedSluttenAvÅret(opptjeningsår)

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/hendelser/VilkårsgrunnlagTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/hendelser/VilkårsgrunnlagTest.kt
@@ -132,8 +132,8 @@ internal class VilkårsgrunnlagTest {
         forventetAntallOpptjeningsdager: Int,
         forventetHarOpptjening: Boolean
     ) {
-        val arbeidsgiverInspektør = TestArbeidsgiverInspektør(person, orgnummer)
-        val grunnlagsdata = arbeidsgiverInspektør.vilkårsgrunnlag { observatør.vedtaksperiode(orgnummer, 0) } as VilkårsgrunnlagHistorikk.Grunnlagsdata
+        val grunnlagsdata =
+            TestArbeidsgiverInspektør(person, orgnummer).vilkårsgrunnlag { observatør.vedtaksperiode(orgnummer, 0) } ?: fail("Forventet at vilkårsgrunnlag er satt")
         val grunnlagsdataInspektør = GrunnlagsdataInspektør(grunnlagsdata)
         assertEquals(forventetSammenligningsgrunnlag, grunnlagsdataInspektør.sammenligningsgrunnlag)
         assertEquals(forventetAvviksprosent, grunnlagsdataInspektør.avviksprosent)

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -107,7 +107,8 @@ internal class TestArbeidsgiverInspektør(
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
-            antallOpptjeningsdagerErMinst: Int
+            antallOpptjeningsdagerErMinst: Int,
+            harOpptjening: Boolean
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -110,7 +110,8 @@ internal class TestArbeidsgiverInspektør(
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
-            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+            harMinimumInntekt: Boolean?
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -3,6 +3,7 @@ package no.nav.helse.inspectors
 import no.nav.helse.antallEtterspurteBehov
 import no.nav.helse.etterspurteBehov
 import no.nav.helse.etterspurteBehovFinnes
+import no.nav.helse.hendelser.Medlemskapsvurdering
 import no.nav.helse.hendelser.Periode
 import no.nav.helse.person.*
 import no.nav.helse.sykdomstidslinje.Sykdomshistorikk
@@ -108,7 +109,8 @@ internal class TestArbeidsgiverInspektør(
             sammenligningsgrunnlag: Inntekt,
             avviksprosent: Prosent?,
             antallOpptjeningsdagerErMinst: Int,
-            harOpptjening: Boolean
+            harOpptjening: Boolean,
+            medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -99,7 +99,11 @@ internal class TestArbeidsgiverInspektør(
             this.arbeidsgiver = arbeidsgiver
         }
 
-        override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
+        override fun preVisitGrunnlagsdata(
+            skjæringstidspunkt: LocalDate,
+            grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+            sykepengegrunnlag: Sykepengegrunnlag
+        ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -11,6 +11,7 @@ import no.nav.helse.utbetalingslinjer.*
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinjeberegning
 import no.nav.helse.økonomi.Inntekt
+import no.nav.helse.økonomi.Prosent
 import org.junit.jupiter.api.fail
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -104,7 +105,8 @@ internal class TestArbeidsgiverInspektør(
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
-            sammenligningsgrunnlag: Inntekt
+            sammenligningsgrunnlag: Inntekt,
+            avviksprosent: Prosent?
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -106,7 +106,8 @@ internal class TestArbeidsgiverInspektør(
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
             sykepengegrunnlag: Sykepengegrunnlag,
             sammenligningsgrunnlag: Inntekt,
-            avviksprosent: Prosent?
+            avviksprosent: Prosent?,
+            antallOpptjeningsdagerErMinst: Int
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -10,6 +10,7 @@ import no.nav.helse.sykdomstidslinje.Sykdomstidslinje
 import no.nav.helse.utbetalingslinjer.*
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinje
 import no.nav.helse.utbetalingstidslinje.Utbetalingstidslinjeberegning
+import no.nav.helse.økonomi.Inntekt
 import org.junit.jupiter.api.fail
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -102,7 +103,8 @@ internal class TestArbeidsgiverInspektør(
         override fun preVisitGrunnlagsdata(
             skjæringstidspunkt: LocalDate,
             grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
-            sykepengegrunnlag: Sykepengegrunnlag
+            sykepengegrunnlag: Sykepengegrunnlag,
+            sammenligningsgrunnlag: Inntekt
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -111,7 +111,8 @@ internal class TestArbeidsgiverInspektør(
             antallOpptjeningsdagerErMinst: Int,
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-            harMinimumInntekt: Boolean?
+            harMinimumInntekt: Boolean?,
+            vurdertOk: Boolean
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -112,7 +112,8 @@ internal class TestArbeidsgiverInspektør(
             harOpptjening: Boolean,
             medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
             harMinimumInntekt: Boolean?,
-            vurdertOk: Boolean
+            vurdertOk: Boolean,
+            meldingsreferanseId: UUID?
         ) {
             vilkårsgrunnlagHistorikk.add(skjæringstidspunkt to grunnlagsdata)
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -35,7 +35,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -74,7 +75,8 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
-        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
+        harMinimumInntekt: Boolean?
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.inspectors
 
+import no.nav.helse.hendelser.Medlemskapsvurdering
 import no.nav.helse.person.Sykepengegrunnlag
 import no.nav.helse.person.VilkårsgrunnlagHistorikk
 import no.nav.helse.person.VilkårsgrunnlagHistorikkVisitor
@@ -33,7 +34,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
-        harOpptjening: Boolean
+        harOpptjening: Boolean,
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -71,7 +73,8 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
         antallOpptjeningsdagerErMinst: Int,
-        harOpptjening: Boolean
+        harOpptjening: Boolean,
+        medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -67,6 +67,8 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         private set
     internal var meldingsreferanseId: UUID? = null
         private set
+    internal var vurdertOk by Delegates.notNull<Boolean>()
+        private set
     init {
         grunnlagsdata.accept(LocalDate.now(), this)
     }
@@ -90,5 +92,6 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         this.antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst
         this.harOpptjening = harOpptjening
         this.meldingsreferanseId = meldingsreferanseId
+        this.vurdertOk = vurdertOk
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -32,7 +32,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
-        antallOpptjeningsdagerErMinst: Int
+        antallOpptjeningsdagerErMinst: Int,
+        harOpptjening: Boolean
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -69,12 +70,13 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
         avviksprosent: Prosent?,
-        antallOpptjeningsdagerErMinst: Int
+        antallOpptjeningsdagerErMinst: Int,
+        harOpptjening: Boolean
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag
         this.avviksprosent = avviksprosent
         this.antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst
-        this.harOpptjening = grunnlagsdata.harOpptjening
+        this.harOpptjening = harOpptjening
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -31,7 +31,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
-        avviksprosent: Prosent?
+        avviksprosent: Prosent?,
+        antallOpptjeningsdagerErMinst: Int
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -67,12 +68,13 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
         sammenligningsgrunnlag: Inntekt,
-        avviksprosent: Prosent?
+        avviksprosent: Prosent?,
+        antallOpptjeningsdagerErMinst: Int
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag
         this.avviksprosent = avviksprosent
-        this.antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst
+        this.antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst
         this.harOpptjening = grunnlagsdata.harOpptjening
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -54,7 +54,7 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
     }
 }
 
-internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) : VilkårsgrunnlagHistorikkVisitor {
+internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.VilkårsgrunnlagElement) : VilkårsgrunnlagHistorikkVisitor {
     internal lateinit var sykepengegrunnlag: Sykepengegrunnlag
         private set
     internal lateinit var sammenligningsgrunnlag: Inntekt

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -23,7 +23,11 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         this.innslag += 1
     }
 
-    override fun preVisitGrunnlagsdata(skjæringstidspunkt: LocalDate, grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
+    override fun preVisitGrunnlagsdata(
+        skjæringstidspunkt: LocalDate,
+        grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
+        sykepengegrunnlag: Sykepengegrunnlag
+    ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -36,7 +36,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -76,7 +77,8 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         antallOpptjeningsdagerErMinst: Int,
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
-        harMinimumInntekt: Boolean?
+        harMinimumInntekt: Boolean?,
+        vurdertOk: Boolean
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -1,6 +1,5 @@
 package no.nav.helse.inspectors
 
-import no.nav.helse.hendelser.VilkårsgrunnlagTest
 import no.nav.helse.person.Sykepengegrunnlag
 import no.nav.helse.person.VilkårsgrunnlagHistorikk
 import no.nav.helse.person.VilkårsgrunnlagHistorikkVisitor
@@ -31,7 +30,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
-        sammenligningsgrunnlag: Inntekt
+        sammenligningsgrunnlag: Inntekt,
+        avviksprosent: Prosent?
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -66,11 +66,12 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         skjæringstidspunkt: LocalDate,
         grunnlagsdata: VilkårsgrunnlagHistorikk.Grunnlagsdata,
         sykepengegrunnlag: Sykepengegrunnlag,
-        sammenligningsgrunnlag: Inntekt
+        sammenligningsgrunnlag: Inntekt,
+        avviksprosent: Prosent?
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag
-        this.avviksprosent = grunnlagsdata.avviksprosent
+        this.avviksprosent = avviksprosent
         this.antallOpptjeningsdagerErMinst = grunnlagsdata.antallOpptjeningsdagerErMinst
         this.harOpptjening = grunnlagsdata.harOpptjening
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/Vilkårgrunnlagsinspektør.kt
@@ -37,7 +37,8 @@ internal class Vilkårgrunnlagsinspektør(historikk: VilkårsgrunnlagHistorikk) 
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {
         val teller = vilkårsgrunnlagTeller.getOrDefault(innslag, 0)
         vilkårsgrunnlagTeller[innslag] = teller.inc()
@@ -64,6 +65,8 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         private set
     internal var harOpptjening by Delegates.notNull<Boolean>()
         private set
+    internal var meldingsreferanseId: UUID? = null
+        private set
     init {
         grunnlagsdata.accept(LocalDate.now(), this)
     }
@@ -78,12 +81,14 @@ internal class GrunnlagsdataInspektør(grunnlagsdata: VilkårsgrunnlagHistorikk.
         harOpptjening: Boolean,
         medlemskapstatus: Medlemskapsvurdering.Medlemskapstatus,
         harMinimumInntekt: Boolean?,
-        vurdertOk: Boolean
+        vurdertOk: Boolean,
+        meldingsreferanseId: UUID?
     ) {
         this.sykepengegrunnlag = sykepengegrunnlag
         this.sammenligningsgrunnlag = sammenligningsgrunnlag
         this.avviksprosent = avviksprosent
         this.antallOpptjeningsdagerErMinst = antallOpptjeningsdagerErMinst
         this.harOpptjening = harOpptjening
+        this.meldingsreferanseId = meldingsreferanseId
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHendelseTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHendelseTest.kt
@@ -12,8 +12,7 @@ import no.nav.helse.økonomi.Inntekt
 import no.nav.helse.økonomi.Inntekt.Companion.månedlig
 import no.nav.helse.økonomi.Inntekt.Companion.årlig
 import no.nav.helse.økonomi.Prosentdel.Companion.prosent
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.*
@@ -68,7 +67,8 @@ internal class VilkårsgrunnlagHendelseTest : AbstractPersonTest() {
             arbeidsforhold = ansattSidenStart2017()
         )
 
-        val grunnlagsdataInspektør = GrunnlagsdataInspektør(inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata)
+        val vilkårsgrunnlag = inspektør.vilkårsgrunnlag(1.vedtaksperiode) ?: fail("Forventet at vilkårsgrunnlag er satt")
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(vilkårsgrunnlag)
         assertEquals(1, inspektør.vedtaksperiodeTeller)
         assertEquals(148000.årlig, grunnlagsdataInspektør.sammenligningsgrunnlag)
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHendelseTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHendelseTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.person
 
 import no.nav.helse.etterspurtBehov
 import no.nav.helse.hendelser.*
+import no.nav.helse.inspectors.GrunnlagsdataInspektør
 import no.nav.helse.person.Aktivitetslogg.Aktivitet.Behov.Behovtype
 import no.nav.helse.person.TilstandType.AVVENTER_HISTORIKK
 import no.nav.helse.person.TilstandType.TIL_INFOTRYGD
@@ -67,8 +68,9 @@ internal class VilkårsgrunnlagHendelseTest : AbstractPersonTest() {
             arbeidsforhold = ansattSidenStart2017()
         )
 
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata)
         assertEquals(1, inspektør.vedtaksperiodeTeller)
-        assertEquals(148000.årlig, (inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata?)?.sammenligningsgrunnlag)
+        assertEquals(148000.årlig, grunnlagsdataInspektør.sammenligningsgrunnlag)
     }
 
     @Test

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
@@ -3,6 +3,7 @@ package no.nav.helse.person
 import no.nav.helse.Fødselsnummer
 import no.nav.helse.hendelser.Medlemskapsvurdering
 import no.nav.helse.testhelpers.januar
+import no.nav.helse.utbetalingstidslinje.Alder
 import no.nav.helse.utbetalingstidslinje.Begrunnelse
 import no.nav.helse.økonomi.Inntekt
 import no.nav.helse.økonomi.Prosent.Companion.prosent
@@ -89,7 +90,6 @@ internal class VilkårsgrunnlagHistorikkInnslagTest {
 
     private val testgrunnlag
         get() = object : VilkårsgrunnlagHistorikk.VilkårsgrunnlagElement {
-            override fun vurdertOk(): Boolean = true
             override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {}
 
             override fun sykepengegrunnlag() = Inntekt.INGEN
@@ -101,6 +101,7 @@ internal class VilkårsgrunnlagHistorikkInnslagTest {
             override fun inntektsopplysningPerArbeidsgiver(): Map<String, Inntektshistorikk.Inntektsopplysning> = emptyMap()
 
             override fun gjelderFlereArbeidsgivere() = false
+            override fun begrunnelserForAvvisteVilkår(alder: Alder, skjæringstidspunkt: LocalDate): List<Begrunnelse> = emptyList()
 
             override fun valider(aktivitetslogg: Aktivitetslogg) {}
         }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
@@ -89,7 +89,7 @@ internal class VilkårsgrunnlagHistorikkInnslagTest {
 
     private val testgrunnlag
         get() = object : VilkårsgrunnlagHistorikk.VilkårsgrunnlagElement {
-            override fun isOk(): Boolean = true
+            override fun vurdertOk(): Boolean = true
             override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {}
 
             override fun sykepengegrunnlag() = Inntekt.INGEN

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
@@ -1,0 +1,107 @@
+package no.nav.helse.person
+
+import no.nav.helse.Fødselsnummer
+import no.nav.helse.hendelser.Medlemskapsvurdering
+import no.nav.helse.testhelpers.januar
+import no.nav.helse.utbetalingstidslinje.Begrunnelse
+import no.nav.helse.økonomi.Inntekt
+import no.nav.helse.økonomi.Prosent.Companion.prosent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+internal class VilkårsgrunnlagHistorikkInnslagTest {
+    private lateinit var innslag: VilkårsgrunnlagHistorikk.Innslag
+
+    private companion object {
+        const val UNG_PERSON_FNR_2018 = "12020052345"
+        val ALDER = Fødselsnummer.tilFødselsnummer(UNG_PERSON_FNR_2018).alder()
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        innslag = VilkårsgrunnlagHistorikk.Innslag(UUID.randomUUID(), LocalDateTime.now())
+    }
+
+    @Test
+    fun `finner ikke begrunnelser dersom vilkårsgrunnlag ikke er Grunnlagsdata`() {
+        val innslag = VilkårsgrunnlagHistorikk.Innslag(UUID.randomUUID(), LocalDateTime.now())
+        innslag.add(1.januar, testgrunnlag)
+        assertEquals(0, innslag.finnBegrunnelser(ALDER).size)
+    }
+
+    @Test
+    fun `finner kun begrunnelser fra vilkårsgrunnlag som er Grunnlagsdata`() {
+        innslag.add(1.januar, testgrunnlag)
+        innslag.add(1.januar, grunnlagsdata(1.januar, vurdertOk = false, harOpptjening = false))
+        val begrunnelserMap = innslag.finnBegrunnelser(ALDER)
+        assertEquals(1, begrunnelserMap.size)
+        assertEquals(listOf(Begrunnelse.ManglerOpptjening), begrunnelserMap[1.januar])
+    }
+
+    @Test
+    fun `finner begrunnelser dersom vilkårsgrunnlag er Grunnlagsdata`() {
+        innslag.add(1.januar, grunnlagsdata(1.januar, vurdertOk = false, harOpptjening = false))
+        val begrunnelserMap = innslag.finnBegrunnelser(ALDER)
+        assertEquals(1, begrunnelserMap.size)
+        assertEquals(listOf(Begrunnelse.ManglerOpptjening), begrunnelserMap[1.januar])
+    }
+
+    @Test
+    fun `finner ikke begrunnelser dersom vilkårsgrunnlag er Grunnlagsdata og grunnlaget er vurdert ok`() {
+        innslag.add(1.januar, grunnlagsdata(1.januar, vurdertOk = true))
+        assertEquals(0, innslag.finnBegrunnelser(ALDER).size)
+    }
+
+    @Test
+    fun `finner alle begrunnelser dersom vilkårsgrunnlag er Grunnlagsdata`() {
+        innslag.add(1.januar, grunnlagsdata(1.januar, vurdertOk = false, harMinimumInntekt = false, harOpptjening = false))
+        val begrunnelserMap = innslag.finnBegrunnelser(ALDER)
+        assertEquals(1, begrunnelserMap.size)
+        assertEquals(listOf(Begrunnelse.MinimumInntekt, Begrunnelse.ManglerOpptjening), begrunnelserMap[1.januar])
+    }
+
+    @Test
+    fun `finner begrunnelser ved flere grunnlagsdata`() {
+        innslag.add(1.januar, grunnlagsdata(1.januar, vurdertOk = false, harOpptjening = false))
+        innslag.add(2.januar, grunnlagsdata(2.januar, vurdertOk = false, harOpptjening = false))
+        val begrunnelserMap = innslag.finnBegrunnelser(ALDER)
+        assertEquals(2, begrunnelserMap.size)
+        assertEquals(listOf(Begrunnelse.ManglerOpptjening), begrunnelserMap[1.januar])
+        assertEquals(listOf(Begrunnelse.ManglerOpptjening), begrunnelserMap[2.januar])
+    }
+
+    private fun grunnlagsdata(skjæringstidspunkt: LocalDate, vurdertOk: Boolean = true, harOpptjening: Boolean = true, harMinimumInntekt: Boolean = true) =
+        VilkårsgrunnlagHistorikk.Grunnlagsdata(
+            Sykepengegrunnlag(emptyList(), skjæringstidspunkt, Aktivitetslogg()),
+            sammenligningsgrunnlag = Inntekt.INGEN,
+            avviksprosent = 0.0.prosent,
+            antallOpptjeningsdagerErMinst = 28,
+            harOpptjening = harOpptjening,
+            medlemskapstatus = Medlemskapsvurdering.Medlemskapstatus.Ja,
+            harMinimumInntekt = harMinimumInntekt,
+            vurdertOk = vurdertOk,
+            meldingsreferanseId = UUID.randomUUID()
+        )
+
+    private val testgrunnlag
+        get() = object : VilkårsgrunnlagHistorikk.VilkårsgrunnlagElement {
+            override fun isOk(): Boolean = true
+            override fun accept(skjæringstidspunkt: LocalDate, vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {}
+
+            override fun sykepengegrunnlag() = Inntekt.INGEN
+
+            override fun grunnlagsBegrensning() = Sykepengegrunnlag.Begrensning.ER_IKKE_6G_BEGRENSET
+
+            override fun grunnlagForSykepengegrunnlag() = Inntekt.INGEN
+
+            override fun inntektsopplysningPerArbeidsgiver(): Map<String, Inntektshistorikk.Inntektsopplysning> = emptyMap()
+
+            override fun gjelderFlereArbeidsgivere() = false
+
+            override fun valider(aktivitetslogg: Aktivitetslogg) {}
+        }
+}

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkTest.kt
@@ -51,7 +51,7 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10000.månedlig), 10000.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         historikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(historikk.vilkårsgrunnlagFor(1.januar))
-        assertTrue(historikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertTrue(historikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
         assertEquals(1, inspektør.vilkårsgrunnlagTeller[0])
     }
 
@@ -87,11 +87,11 @@ internal class VilkårsgrunnlagHistorikkTest {
 
         historikk.lagre(1.januar, vilkårsgrunnlag1)
         assertNotNull(historikk.vilkårsgrunnlagFor(1.januar))
-        assertTrue(historikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertTrue(historikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
 
         historikk.lagre(1.januar, vilkårsgrunnlag2)
         assertNotNull(historikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(historikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertFalse(historikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
 
         assertEquals(1, inspektør.vilkårsgrunnlagTeller[0])
         assertEquals(1, inspektør.vilkårsgrunnlagTeller[1])
@@ -173,7 +173,7 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10000.månedlig), 10000.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertTrue(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertTrue(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
     }
 
     @Test
@@ -194,7 +194,7 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10000.månedlig), 10000.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
     }
 
     @Test
@@ -367,7 +367,7 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10.månedlig), 10.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
         val utbetalingstidslinjeMedNavDager = tidslinjeOf(16.AP, 3.NAV, 2.HELG, 5.NAV)
         vilkårsgrunnlagHistorikk.avvisUtbetalingsdagerMedBegrunnelse(listOf(utbetalingstidslinjeMedNavDager), "20043769969".somFødselsnummer().alder())
         utbetalingstidslinjeMedNavDager.filterIsInstance<Utbetalingstidslinje.Utbetalingsdag.AvvistDag>().let { avvisteDager ->
@@ -398,7 +398,7 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10.månedlig), 10.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.isOk())
+        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
         val utbetalingstidslinjeMedNavDager = tidslinjeOf(16.AP, 3.NAV, 2.HELG, 5.NAV)
         vilkårsgrunnlagHistorikk.avvisUtbetalingsdagerMedBegrunnelse(listOf(utbetalingstidslinjeMedNavDager), fødselsnummer.alder())
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkTest.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.person
 
 import no.nav.helse.hendelser.*
+import no.nav.helse.inspectors.GrunnlagsdataInspektør
 import no.nav.helse.inspectors.Vilkårgrunnlagsinspektør
 import no.nav.helse.person.Sykepengegrunnlag.Begrensning.ER_IKKE_6G_BEGRENSET
 import no.nav.helse.person.infotrygdhistorikk.Infotrygdhistorikk
@@ -51,7 +52,8 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10000.månedlig), 10000.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         historikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(historikk.vilkårsgrunnlagFor(1.januar))
-        assertTrue(historikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(historikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertTrue(grunnlagsdataInspektør.vurdertOk)
         assertEquals(1, inspektør.vilkårsgrunnlagTeller[0])
     }
 
@@ -87,11 +89,13 @@ internal class VilkårsgrunnlagHistorikkTest {
 
         historikk.lagre(1.januar, vilkårsgrunnlag1)
         assertNotNull(historikk.vilkårsgrunnlagFor(1.januar))
-        assertTrue(historikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør1 = GrunnlagsdataInspektør(historikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertTrue(grunnlagsdataInspektør1.vurdertOk)
 
         historikk.lagre(1.januar, vilkårsgrunnlag2)
         assertNotNull(historikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(historikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør2 = GrunnlagsdataInspektør(historikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertFalse(grunnlagsdataInspektør2.vurdertOk)
 
         assertEquals(1, inspektør.vilkårsgrunnlagTeller[0])
         assertEquals(1, inspektør.vilkårsgrunnlagTeller[1])
@@ -173,7 +177,8 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10000.månedlig), 10000.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertTrue(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertTrue(grunnlagsdataInspektør.vurdertOk)
     }
 
     @Test
@@ -194,7 +199,8 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10000.månedlig), 10000.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertFalse(grunnlagsdataInspektør.vurdertOk)
     }
 
     @Test
@@ -367,7 +373,8 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10.månedlig), 10.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertFalse(grunnlagsdataInspektør.vurdertOk)
         val utbetalingstidslinjeMedNavDager = tidslinjeOf(16.AP, 3.NAV, 2.HELG, 5.NAV)
         vilkårsgrunnlagHistorikk.avvisUtbetalingsdagerMedBegrunnelse(listOf(utbetalingstidslinjeMedNavDager), "20043769969".somFødselsnummer().alder())
         utbetalingstidslinjeMedNavDager.filterIsInstance<Utbetalingstidslinje.Utbetalingsdag.AvvistDag>().let { avvisteDager ->
@@ -398,7 +405,8 @@ internal class VilkårsgrunnlagHistorikkTest {
         vilkårsgrunnlag.valider(sykepengegrunnlag(10.månedlig), 10.månedlig, 1.januar, 1, Periodetype.FØRSTEGANGSBEHANDLING)
         vilkårsgrunnlagHistorikk.lagre(1.januar, vilkårsgrunnlag)
         assertNotNull(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar))
-        assertFalse(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!.vurdertOk())
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(1.januar)!!)
+        assertFalse(grunnlagsdataInspektør.vurdertOk)
         val utbetalingstidslinjeMedNavDager = tidslinjeOf(16.AP, 3.NAV, 2.HELG, 5.NAV)
         vilkårsgrunnlagHistorikk.avvisUtbetalingsdagerMedBegrunnelse(listOf(utbetalingstidslinjeMedNavDager), fødselsnummer.alder())
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/PeriodeVarslerBuilderTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/PeriodeVarslerBuilderTest.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.serde.api.v2.buildere
 
 import no.nav.helse.hendelser.*
+import no.nav.helse.inspectors.GrunnlagsdataInspektør
 import no.nav.helse.person.IdInnhenter
 import no.nav.helse.person.Vedtaksperiode
 import no.nav.helse.person.VilkårsgrunnlagHistorikk
@@ -85,6 +86,9 @@ internal class PeriodeVarslerBuilderTest: AbstractEndToEndTest() {
     }
 
     private fun meldingsreferanseId(vedtaksperiode: IdInnhenter): UUID? {
-        return inspektør.vilkårsgrunnlag(vedtaksperiode)?.let { it as? VilkårsgrunnlagHistorikk.Grunnlagsdata }?.meldingsreferanseId
+        return inspektør.vilkårsgrunnlag(vedtaksperiode)
+            ?.let { it as? VilkårsgrunnlagHistorikk.Grunnlagsdata }
+            ?.let { GrunnlagsdataInspektør(it) }
+            ?.meldingsreferanseId
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/InntekterForFlereArbeidsgivereTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/InntekterForFlereArbeidsgivereTest.kt
@@ -89,7 +89,7 @@ internal class InntekterForFlereArbeidsgivereTest : AbstractEndToEndTest() {
         assertInntektForDato(4750.månedlig, 1.januar, a3Inspektør)
         assertInntektForDato(2250.månedlig, 1.januar, a4Inspektør)
 
-        val grunnlagsdataInspektør = GrunnlagsdataInspektør(a1Inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata)
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(a1Inspektør.vilkårsgrunnlag(1.vedtaksperiode)!!)
         assertEquals(300000.årlig, grunnlagsdataInspektør.sammenligningsgrunnlag)
 
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/InntekterForFlereArbeidsgivereTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/InntekterForFlereArbeidsgivereTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.spleis.e2e
 
 import no.nav.helse.hendelser.*
 import no.nav.helse.hendelser.Søknad.Søknadsperiode.Sykdom
+import no.nav.helse.inspectors.GrunnlagsdataInspektør
 import no.nav.helse.inspectors.Kilde
 import no.nav.helse.inspectors.TestArbeidsgiverInspektør
 import no.nav.helse.person.IdInnhenter
@@ -88,8 +89,8 @@ internal class InntekterForFlereArbeidsgivereTest : AbstractEndToEndTest() {
         assertInntektForDato(4750.månedlig, 1.januar, a3Inspektør)
         assertInntektForDato(2250.månedlig, 1.januar, a4Inspektør)
 
-        val vilkårsgrunnlag = a1Inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata?
-        assertEquals(300000.årlig, vilkårsgrunnlag?.sammenligningsgrunnlag)
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(a1Inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata)
+        assertEquals(300000.årlig, grunnlagsdataInspektør.sammenligningsgrunnlag)
 
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverTest.kt
@@ -1140,7 +1140,7 @@ internal class KunEnArbeidsgiverTest : AbstractEndToEndTest() {
             MOTTATT_SYKMELDING_UFERDIG_FORLENGELSE,
             MOTTATT_SYKMELDING_FERDIG_GAP
         )
-        val grunnlagsdataInspektør = GrunnlagsdataInspektør(inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata)
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(inspektør.vilkårsgrunnlag(1.vedtaksperiode)!!)
         assertEquals(INNTEKT, grunnlagsdataInspektør.sammenligningsgrunnlag)
         assertNull(inspektør.vilkårsgrunnlag(2.vedtaksperiode))
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverTest.kt
@@ -4,6 +4,7 @@ import no.nav.helse.ForventetFeil
 import no.nav.helse.hendelser.*
 import no.nav.helse.hendelser.Inntektsmelding.Refusjon
 import no.nav.helse.hendelser.Søknad.Søknadsperiode.*
+import no.nav.helse.inspectors.GrunnlagsdataInspektør
 import no.nav.helse.inspectors.inspektør
 import no.nav.helse.person.Aktivitetslogg
 import no.nav.helse.person.PersonObserver
@@ -1139,7 +1140,8 @@ internal class KunEnArbeidsgiverTest : AbstractEndToEndTest() {
             MOTTATT_SYKMELDING_UFERDIG_FORLENGELSE,
             MOTTATT_SYKMELDING_FERDIG_GAP
         )
-        assertEquals(INNTEKT, (inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata?)?.sammenligningsgrunnlag)
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(inspektør.vilkårsgrunnlag(1.vedtaksperiode) as VilkårsgrunnlagHistorikk.Grunnlagsdata)
+        assertEquals(INNTEKT, grunnlagsdataInspektør.sammenligningsgrunnlag)
         assertNull(inspektør.vilkårsgrunnlag(2.vedtaksperiode))
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderInntektTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderInntektTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.spleis.e2e
 
 import no.nav.helse.hendelser.*
 import no.nav.helse.hendelser.Inntektsmelding.Refusjon
+import no.nav.helse.inspectors.GrunnlagsdataInspektør
 import no.nav.helse.inspectors.Kilde
 import no.nav.helse.inspectors.inspektør
 import no.nav.helse.person.OppdragVisitor
@@ -36,6 +37,8 @@ internal class RevurderInntektTest : AbstractEndToEndTest() {
         håndterUtbetalingsgodkjenning(1.vedtaksperiode, true)
         håndterUtbetalt(1.vedtaksperiode)
 
+        val grunnlagsdataInspektør = GrunnlagsdataInspektør(inspektør.vilkårsgrunnlagHistorikk[0].second)
+
         assertTilstander(
             0,
             START,
@@ -60,7 +63,7 @@ internal class RevurderInntektTest : AbstractEndToEndTest() {
         assertEquals(506, inspektør.utbetalinger.last().inspektør.arbeidsgiverOppdrag.nettoBeløp())
 
         assertEquals(2, inspektør.vilkårsgrunnlagHistorikk.size)
-        assertEquals(3, inspektør.vilkårsgrunnlagHistorikk[0].second.avviksprosent?.roundToInt())
+        assertEquals(3, grunnlagsdataInspektør.avviksprosent?.roundToInt())
 
         val tidligereBeregning = inspektør.utbetalingstidslinjeberegningData.first()
         assertEquals(tidligereBeregning.inntektshistorikkInnslagId, tidligereInntektInnslagId)

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingstidslinje/AlderTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingstidslinje/AlderTest.kt
@@ -5,10 +5,14 @@ import no.nav.helse.somFødselsnummer
 import no.nav.helse.testhelpers.februar
 import no.nav.helse.testhelpers.januar
 import no.nav.helse.økonomi.Inntekt.Companion.årlig
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 internal class AlderTest {
+
+    private companion object {
+        val FYLLER_67_1_JANUAR_2018 = "01015149945".somFødselsnummer().alder()
+    }
 
     @Test
     fun `alder på gitt dato`() {
@@ -19,25 +23,39 @@ internal class AlderTest {
 
     @Test
     fun `Minimum inntekt er en halv g hvis du akkurat har fylt 67`() {
-        val alder = "01015149945".somFødselsnummer().alder()
-        assertEquals(67, alder.alderPåDato(1.januar))
-        assertEquals(Grunnbeløp.halvG.beløp(1.januar), alder.minimumInntekt(1.januar))
-        assertEquals((93634 / 2).årlig, alder.minimumInntekt(1.januar))
+        assertEquals(67, FYLLER_67_1_JANUAR_2018.alderPåDato(1.januar))
+        assertEquals(Grunnbeløp.halvG.beløp(1.januar), FYLLER_67_1_JANUAR_2018.minimumInntekt(1.januar))
+        assertEquals((93634 / 2).årlig, FYLLER_67_1_JANUAR_2018.minimumInntekt(1.januar))
     }
 
     @Test
     fun `Minimum inntekt er 2g hvis du er en dag over 67`() {
-        val alder = "01015149945".somFødselsnummer().alder()
-        assertEquals(67, alder.alderPåDato(2.januar))
-        assertEquals(Grunnbeløp.`2G`.beløp(2.januar), alder.minimumInntekt(2.januar))
-        assertEquals((93634 * 2).årlig, alder.minimumInntekt(2.januar))
+        assertEquals(67, FYLLER_67_1_JANUAR_2018.alderPåDato(2.januar))
+        assertEquals(Grunnbeløp.`2G`.beløp(2.januar), FYLLER_67_1_JANUAR_2018.minimumInntekt(2.januar))
+        assertEquals((93634 * 2).årlig, FYLLER_67_1_JANUAR_2018.minimumInntekt(2.januar))
     }
 
     @Test
     fun `Minimum inntekt er 2g hvis du er 69`() {
-        val alder = "01014949945".somFødselsnummer().alder()
-        assertEquals(69, alder.alderPåDato(1.januar))
-        assertEquals(Grunnbeløp.`2G`.beløp(1.januar), alder.minimumInntekt(1.januar))
-        assertEquals((93634 * 2).årlig, alder.minimumInntekt(1.januar))
+        val FYLLER_69_1_JANUAR_2018 = "01014949945".somFødselsnummer().alder()
+        assertEquals(69, FYLLER_69_1_JANUAR_2018.alderPåDato(1.januar))
+        assertEquals(Grunnbeløp.`2G`.beløp(1.januar), FYLLER_69_1_JANUAR_2018.minimumInntekt(1.januar))
+        assertEquals((93634 * 2).årlig, FYLLER_69_1_JANUAR_2018.minimumInntekt(1.januar))
+    }
+
+    @Test
+    fun `forhøyet inntektskrav`() {
+        assertFalse(FYLLER_67_1_JANUAR_2018.forhøyetInntektskrav(1.januar))
+        assertTrue(FYLLER_67_1_JANUAR_2018.forhøyetInntektskrav(2.januar))
+    }
+
+    @Test
+    fun `riktig begrunnelse for minimum inntekt ved alder over 67`() {
+        assertEquals(Begrunnelse.MinimumInntektOver67, FYLLER_67_1_JANUAR_2018.begrunnelseForMinimumInntekt(2.januar))
+    }
+
+    @Test
+    fun `riktig begrunnelse for minimum inntekt ved alder 67 eller under`() {
+        assertEquals(Begrunnelse.MinimumInntekt, FYLLER_67_1_JANUAR_2018.begrunnelseForMinimumInntekt(1.januar))
     }
 }


### PR DESCRIPTION
I korte trekk:
* Flippet alle internal vals til private, bruker visitor-interface'et i stedet. 
* Flytt oppførsel relatert til begrunnelser _inn i_ `Grunnlagsdata`, der det hører hjemme. I tillegg; tester.
* Egen inspektør for å besøke `Grunnlagsdata`.
* Egen liten builder for `Grunnlagsdata` i gammel speil builder