### PR TITLE
Implementer og test etterlevelse av §8-30 første ledd

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Aktivitetslogg.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Aktivitetslogg.kt
@@ -711,9 +711,28 @@ class Aktivitetslogg(
 
                     internal fun IAktivitetslogg.`§8-30 ledd 1`(
                         oppfylt: Boolean,
-                        list: List<ArbeidsgiverInntektsopplysning>,
+                        grunnlagForSykepengegrunnlagPerArbeidsgiver: Map<String, Inntekt>,
                         grunnlagForSykepengegrunnlag: Inntekt
-                    ) {}
+                    ) {
+                        val beregnetMånedsinntektPerArbeidsgiver = grunnlagForSykepengegrunnlagPerArbeidsgiver
+                            .mapValues { it.value.reflection { _, månedlig, _, _ -> månedlig } }
+                        juridiskVurdering(
+                            "",
+                            Vurderingsresultat(
+                                oppfylt = oppfylt,
+                                versjon = LocalDate.of(2019, 1, 1),
+                                paragraf = PARAGRAF_8_30,
+                                ledd = LEDD_1,
+                                punktum = 1.punktum,
+                                inputdata = mapOf(
+                                    "beregnetMånedsinntektPerArbeidsgiver" to beregnetMånedsinntektPerArbeidsgiver
+                                ),
+                                outputdata = mapOf(
+                                    "grunnlagForSykepengegrunnlag" to grunnlagForSykepengegrunnlag.reflection { årlig, _, _, _ -> årlig }
+                                )
+                            )
+                        )
+                    }
 
                     internal fun IAktivitetslogg.`§8-30 ledd 2 punktum 1`(
                         oppfylt: Boolean,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/ArbeidsgiverInntektsopplysning.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/ArbeidsgiverInntektsopplysning.kt
@@ -13,9 +13,12 @@ internal class ArbeidsgiverInntektsopplysning(private val orgnummer: String, pri
     }
 
     companion object {
-        internal fun List<ArbeidsgiverInntektsopplysning>.inntekt(): Inntekt {
+        internal fun List<ArbeidsgiverInntektsopplysning>.inntekt(aktivitetslogg: IAktivitetslogg): Inntekt {
             val grunnlagForSykepengegrunnlag = map { it.inntektsopplysning.grunnlagForSykepengegrunnlag() }.summer()
-            Aktivitetslogg().`§8-30 ledd 1`(true, this, grunnlagForSykepengegrunnlag)
+            val grunnlagForSykepengegrunnlagPerArbeidsgiver = this
+                .associateBy { it.orgnummer }
+                .mapValues { it.value.inntektsopplysning.grunnlagForSykepengegrunnlag() }
+            aktivitetslogg.`§8-30 ledd 1`(true, grunnlagForSykepengegrunnlagPerArbeidsgiver, grunnlagForSykepengegrunnlag)
             return grunnlagForSykepengegrunnlag
         }
         internal fun List<ArbeidsgiverInntektsopplysning>.inntektsopplysningPerArbeidsgiver() = associate { it.orgnummer to it.inntektsopplysning }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
@@ -449,9 +449,9 @@ class Person private constructor(
         vilkårsgrunnlagHistorikk.lagre(skjæringstidspunkt, vilkårsgrunnlag)
     }
 
-    internal fun lagreVilkårsgrunnlagFraInfotrygd(skjæringstidspunkt: LocalDate, periode: Periode) {
+    internal fun lagreVilkårsgrunnlagFraInfotrygd(skjæringstidspunkt: LocalDate, periode: Periode, hendelse: IAktivitetslogg) {
         infotrygdhistorikk.lagreVilkårsgrunnlag(skjæringstidspunkt, vilkårsgrunnlagHistorikk) {
-            beregnSykepengegrunnlagForInfotrygd(it, periode.start)
+            beregnSykepengegrunnlagForInfotrygd(it, periode.start, hendelse)
         }
     }
 
@@ -494,8 +494,12 @@ class Person private constructor(
     internal fun beregnSykepengegrunnlag(skjæringstidspunkt: LocalDate, aktivitetslogg: IAktivitetslogg) =
         Sykepengegrunnlag(arbeidsgivere.beregnSykepengegrunnlag(skjæringstidspunkt), skjæringstidspunkt, aktivitetslogg)
 
-    private fun beregnSykepengegrunnlagForInfotrygd(skjæringstidspunkt: LocalDate, personensSisteKjenteSykedagIDenSammenhengdendeSykeperioden: LocalDate) =
-        Sykepengegrunnlag(arbeidsgivere.beregnSykepengegrunnlag(skjæringstidspunkt, personensSisteKjenteSykedagIDenSammenhengdendeSykeperioden))
+    private fun beregnSykepengegrunnlagForInfotrygd(
+        skjæringstidspunkt: LocalDate,
+        personensSisteKjenteSykedagIDenSammenhengdendeSykeperioden: LocalDate,
+        hendelse: IAktivitetslogg
+    ) =
+        Sykepengegrunnlag(arbeidsgivere.beregnSykepengegrunnlag(skjæringstidspunkt, personensSisteKjenteSykedagIDenSammenhengdendeSykeperioden), hendelse)
 
     internal fun grunnlagForSykepengegrunnlagPerArbeidsgiver(skjæringstidspunkt: LocalDate) =
         vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(skjæringstidspunkt)?.inntektsopplysningPerArbeidsgiver()

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Sykepengegrunnlag.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Sykepengegrunnlag.kt
@@ -44,18 +44,39 @@ internal class Sykepengegrunnlag(
         skjæringstidspunkt: LocalDate,
         aktivitetslogg: IAktivitetslogg
     ) : this(
-        sykepengegrunnlag(arbeidsgiverInntektsopplysninger.inntekt(), skjæringstidspunkt, aktivitetslogg),
         arbeidsgiverInntektsopplysninger,
-        arbeidsgiverInntektsopplysninger.inntekt(),
-        if (arbeidsgiverInntektsopplysninger.inntekt() > Grunnbeløp.`6G`.beløp(skjæringstidspunkt)) ER_6G_BEGRENSET else ER_IKKE_6G_BEGRENSET
+        skjæringstidspunkt,
+        aktivitetslogg,
+        arbeidsgiverInntektsopplysninger.inntekt(aktivitetslogg)
     )
 
     constructor(
         arbeidsgiverInntektsopplysninger: List<ArbeidsgiverInntektsopplysning>,
+        aktivitetslogg: IAktivitetslogg
     ) : this(
-        arbeidsgiverInntektsopplysninger.inntekt(),
         arbeidsgiverInntektsopplysninger,
-        arbeidsgiverInntektsopplysninger.inntekt(),
+        arbeidsgiverInntektsopplysninger.inntekt(aktivitetslogg)
+    )
+
+    private constructor(
+        arbeidsgiverInntektsopplysninger: List<ArbeidsgiverInntektsopplysning>,
+        skjæringstidspunkt: LocalDate,
+        aktivitetslogg: IAktivitetslogg,
+        grunnlagForSykepengegrunnlag: Inntekt,
+    ): this(
+        sykepengegrunnlag(grunnlagForSykepengegrunnlag, skjæringstidspunkt, aktivitetslogg),
+        arbeidsgiverInntektsopplysninger,
+        grunnlagForSykepengegrunnlag,
+        if (grunnlagForSykepengegrunnlag > Grunnbeløp.`6G`.beløp(skjæringstidspunkt)) ER_6G_BEGRENSET else ER_IKKE_6G_BEGRENSET
+    )
+
+    private constructor(
+        arbeidsgiverInntektsopplysninger: List<ArbeidsgiverInntektsopplysning>,
+        grunnlagForSykepengegrunnlag: Inntekt
+    ): this (
+        grunnlagForSykepengegrunnlag,
+        arbeidsgiverInntektsopplysninger,
+        grunnlagForSykepengegrunnlag,
         VURDERT_I_INFOTRYGD
     )
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
@@ -1995,7 +1995,7 @@ internal class Vedtaksperiode private constructor(
                 }
                 onSuccess { infotrygdhistorikk.addInntekter(person, this) }
                 onSuccess {
-                    person.lagreVilkårsgrunnlagFraInfotrygd(vedtaksperiode.skjæringstidspunkt, vedtaksperiode.periode())
+                    person.lagreVilkårsgrunnlagFraInfotrygd(vedtaksperiode.skjæringstidspunkt, vedtaksperiode.periode(), ytelser)
                 }
                 validerHvis(
                     "Forventer minst ett sykepengegrunnlag som er fra inntektsmelding eller Infotrygd",


### PR DESCRIPTION
Hovedpunkter:

* Ta inn aktivitetslogg på `inntekt`-funksjon i companion på `ArbeidsgiverInntektsopplysning`
* Refaktorert konstruktører i `Sykepengegrunnlag` for å sørge for at `inntekt` kun blir kalt én gang per konstruksjon. Kan evt. erstattes av factory-metoder. 
* Input og output bør kontrolleres. Blant annet: reverse mapper årlig inntekt tilbake til månedlig inntekt (per arbeidsgiver) og sender disse med som output.