### PR TITLE
må runde av grad før utbetalingslinjer bygges

### DIFF
--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverMediatorTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverMediatorTest.kt
@@ -22,7 +22,6 @@ import no.nav.syfo.kafka.felles.FravarDTO
 import no.nav.syfo.kafka.felles.FravarstypeDTO
 import no.nav.syfo.kafka.felles.SoknadsperiodeDTO
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -493,7 +492,6 @@ internal class KunEnArbeidsgiverMediatorTest : AbstractEndToEndMediatorTest() {
         verify(exactly = 2) { hendelseRepository.markerSomBehandlet(meldingId) }
     }
 
-    @Disabled("https://trello.com/c/Ob6kSelp")
     @Test
     fun `spleis sender korrekt grad (avrundet) ut`() {
         sendNySøknad(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -986,7 +986,7 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         satstype: Satstype,
         beløp: Int?,
         aktuellDagsinntekt: Int?,
-        grad: Double?,
+        grad: Int?,
         delytelseId: Int,
         refDelytelseId: Int?,
         refFagsystemId: String?,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonObserver.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonObserver.kt
@@ -62,7 +62,7 @@ interface PersonObserver {
                 val tom: LocalDate,
                 val sats: Int,
                 val beløp: Int,
-                val grad: Double,
+                val grad: Int,
                 val sykedager: Int
             )
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/PersonVisitor.kt
@@ -674,7 +674,7 @@ internal interface OppdragVisitor {
         satstype: Satstype,
         beløp: Int?,
         aktuellDagsinntekt: Int?,
-        grad: Double?,
+        grad: Int?,
         delytelseId: Int,
         refDelytelseId: Int?,
         refFagsystemId: String?,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/UtbetaltEventBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/UtbetaltEventBuilder.kt
@@ -147,7 +147,7 @@ private class UtbetaltEventBuilder(
         satstype: Satstype,
         beløp: Int?,
         aktuellDagsinntekt: Int?,
-        grad: Double?,
+        grad: Int?,
         delytelseId: Int,
         refDelytelseId: Int?,
         refFagsystemId: String?,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -423,7 +423,7 @@ internal class JsonBuilder : AbstractBuilder() {
             satstype: Satstype,
             beløp: Int?,
             aktuellDagsinntekt: Int?,
-            grad: Double?,
+            grad: Int?,
             delytelseId: Int,
             refDelytelseId: Int?,
             refFagsystemId: String?,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/PersonData.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/PersonData.kt
@@ -1130,7 +1130,7 @@ internal data class PersonData(
         private val satstype: String,
         private val sats: Int,
         private val lønn: Int?,
-        private val grad: Double?,
+        private val grad: Int?,
         private val refFagsystemId: String?,
         private val delytelseId: Int,
         private val refDelytelseId: Int?,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/SpeilBuilderDTO.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/SpeilBuilderDTO.kt
@@ -109,7 +109,7 @@ data class UtbetalingerDTO(
         val fom: LocalDate,
         val tom: LocalDate,
         val dagsats: Int,
-        val grad: Double
+        val grad: Int
     )
 }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/OppdragBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/builders/OppdragBuilder.kt
@@ -88,7 +88,7 @@ internal class OppdragBuilder : BuilderState() {
         satstype: Satstype,
         beløp: Int?,
         aktuellDagsinntekt: Int?,
-        grad: Double?,
+        grad: Int?,
         delytelseId: Int,
         refDelytelseId: Int?,
         refFagsystemId: String?,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/migration/V135UtbetalingslinjeGrad.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/migration/V135UtbetalingslinjeGrad.kt
@@ -1,0 +1,29 @@
+package no.nav.helse.serde.migration
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+
+internal class V135UtbetalingslinjeGrad : JsonMigration(version = 135) {
+    override val description = "Migrerer grad på utbetalingslinjer"
+
+    override fun doMigration(jsonNode: ObjectNode, meldingerSupplier: MeldingerSupplier) {
+        jsonNode.path("arbeidsgivere").forEach { arbeidsgiver ->
+            arbeidsgiver.path("feriepengeutbetalinger").forEach { utbetaling ->
+                migrer(utbetaling.path("oppdrag"))
+            }
+            arbeidsgiver.path("utbetalinger").forEach { utbetaling ->
+                migrer(utbetaling.path("arbeidsgiverOppdrag"))
+                migrer(utbetaling.path("personOppdrag"))
+            }
+        }
+    }
+
+    private fun migrer(oppdrag: JsonNode) {
+        oppdrag.path("linjer")
+            .filter { it.hasNonNull("grad") }
+            .forEach { linje ->
+                linje as ObjectNode
+                linje.put("grad", linje.path("grad").asInt())
+            }
+    }
+}

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingslinjer/Fagområde.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingslinjer/Fagområde.kt
@@ -15,10 +15,10 @@ internal enum class Fagområde(
 
     override fun toString() = verdi
 
-    internal fun linje(fagsystemId: String, økonomi: Økonomi, dato: LocalDate, grad: Double, beløp: Int) =
+    internal fun linje(fagsystemId: String, økonomi: Økonomi, dato: LocalDate, grad: Int, beløp: Int) =
         Utbetalingslinje(dato, dato, Satstype.DAG, beløpStrategy(økonomi), beløp, grad, fagsystemId, klassekode = klassekode)
 
-    internal fun linje(fagsystemId: String, dato: LocalDate, grad: Double) =
+    internal fun linje(fagsystemId: String, dato: LocalDate, grad: Int) =
         Utbetalingslinje(dato, dato, Satstype.DAG, null, 0, grad, fagsystemId, klassekode = klassekode)
 
     internal fun oppdaterLinje(linje: Utbetalingslinje, dato: LocalDate, økonomi: Økonomi, beløp: Int) {
@@ -27,7 +27,7 @@ internal enum class Fagområde(
         linje.fom = dato
     }
 
-    internal fun kanLinjeUtvides(linje: Utbetalingslinje, økonomi: Økonomi, grad: Double) =
+    internal fun kanLinjeUtvides(linje: Utbetalingslinje, økonomi: Økonomi, grad: Int) =
         grad == linje.grad && (linje.beløp == null || linje.beløp == beløpStrategy(økonomi))
 
     internal companion object {

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingslinjer/OppdragBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingslinjer/OppdragBuilder.kt
@@ -9,7 +9,6 @@ import no.nav.helse.utbetalingstidslinje.genererUtbetalingsreferanse
 import no.nav.helse.økonomi.Økonomi
 import java.time.LocalDate
 import java.util.*
-import kotlin.math.roundToInt
 
 internal class OppdragBuilder(
     private val tidslinje: Utbetalingstidslinje,
@@ -71,7 +70,7 @@ internal class OppdragBuilder(
         økonomi: Økonomi
     ) {
         // TODO: OppdragBuilder må bruke grad som Int, altså avrundetData
-        økonomi.medData { grad, _, aktuellDagsinntekt ->
+        økonomi.medAvrundetData { grad, _, _, _, _, aktuellDagsinntekt, _, _, _ ->
             if (utbetalingslinjer.isNotEmpty() && fagområde.kanLinjeUtvides(linje, dag.økonomi, grad))
                 tilstand.betalingsdag(dag, dato, grad, aktuellDagsinntekt)
             else
@@ -85,7 +84,7 @@ internal class OppdragBuilder(
         økonomi: Økonomi
     ) {
         // TODO: OppdragBuilder må bruke grad som Int, altså avrundetData
-        økonomi.medData { grad, _, _ ->
+        økonomi.medAvrundetData { grad, _ ->
            if (utbetalingslinjer.isNotEmpty() && grad != linje.grad)
                 tilstand.nyLinje(dag, dato, grad)
             else
@@ -134,11 +133,11 @@ internal class OppdragBuilder(
         tilstand.ikkeBetalingsdag()
     }
 
-    private fun addLinje(dag: Utbetalingsdag, dato: LocalDate, grad: Double, aktuellDagsinntekt: Double) {
-        utbetalingslinjer.add(0, fagområde.linje(fagsystemId, dag.økonomi, dato, grad, aktuellDagsinntekt.roundToInt()))
+    private fun addLinje(dag: Utbetalingsdag, dato: LocalDate, grad: Int, aktuellDagsinntekt: Int) {
+        utbetalingslinjer.add(0, fagområde.linje(fagsystemId, dag.økonomi, dato, grad, aktuellDagsinntekt))
     }
 
-    private fun addLinje(dato: LocalDate, grad: Double) {
+    private fun addLinje(dato: LocalDate, grad: Int) {
         utbetalingslinjer.add(0, fagområde.linje(fagsystemId, dato, grad))
     }
 
@@ -148,30 +147,30 @@ internal class OppdragBuilder(
         fun betalingsdag(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
         }
 
         fun helgedag(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
         }
 
         fun nyLinje(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
         }
 
         fun nyLinje(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
         }
 
@@ -186,8 +185,8 @@ internal class OppdragBuilder(
         override fun betalingsdag(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
             addLinje(dag, dato, grad, aktuellDagsinntekt)
             tilstand = LinjeMedSats()
@@ -197,8 +196,8 @@ internal class OppdragBuilder(
         override fun nyLinje(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
             addLinje(dag, dato, grad, aktuellDagsinntekt)
             tilstand = LinjeMedSats()
@@ -208,7 +207,7 @@ internal class OppdragBuilder(
         override fun helgedag(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
             /* ønsker ikke slutte en linje på helg */
         }
@@ -216,7 +215,7 @@ internal class OppdragBuilder(
         override fun nyLinje(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
             addLinje(dato, grad)
             tilstand = LinjeUtenSats()
@@ -235,8 +234,8 @@ internal class OppdragBuilder(
         override fun betalingsdag(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
             linje.fom = dag.dato
         }
@@ -244,8 +243,8 @@ internal class OppdragBuilder(
         override fun nyLinje(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
             addLinje(dag, dato, grad, aktuellDagsinntekt)
         }
@@ -253,7 +252,7 @@ internal class OppdragBuilder(
         override fun helgedag(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
             linje.fom = dag.dato
         }
@@ -261,7 +260,7 @@ internal class OppdragBuilder(
         override fun nyLinje(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
             addLinje(dato, grad)
             tilstand = LinjeUtenSats()
@@ -280,18 +279,18 @@ internal class OppdragBuilder(
         override fun betalingsdag(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
-            fagområde.oppdaterLinje(linje, dag.dato, dag.økonomi, aktuellDagsinntekt.roundToInt())
+            fagområde.oppdaterLinje(linje, dag.dato, dag.økonomi, aktuellDagsinntekt)
             tilstand = LinjeMedSats()
         }
 
         override fun nyLinje(
             dag: Utbetalingsdag,
             dato: LocalDate,
-            grad: Double,
-            aktuellDagsinntekt: Double
+            grad: Int,
+            aktuellDagsinntekt: Int
         ) {
             addLinje(dag, dato, grad, aktuellDagsinntekt)
             tilstand = LinjeMedSats()
@@ -300,7 +299,7 @@ internal class OppdragBuilder(
         override fun helgedag(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
             linje.fom = dag.dato
         }
@@ -308,7 +307,7 @@ internal class OppdragBuilder(
         override fun nyLinje(
             dag: NavHelgDag,
             dato: LocalDate,
-            grad: Double
+            grad: Int
         ) {
             addLinje(dato, grad)
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingslinjer/Utbetalingslinje.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingslinjer/Utbetalingslinje.kt
@@ -14,7 +14,7 @@ internal class Utbetalingslinje internal constructor(
     internal var satstype: Satstype = Satstype.DAG,
     internal var beløp: Int?,
     internal var aktuellDagsinntekt: Int?,
-    internal val grad: Double?,
+    internal val grad: Int?,
     internal var refFagsystemId: String? = null,
     private var delytelseId: Int = 1,
     private var refDelytelseId: Int? = null,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Feriepengeberegner.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Feriepengeberegner.kt
@@ -268,7 +268,7 @@ internal class Feriepengeberegner(
                 satstype: Satstype,
                 beløp: Int?,
                 aktuellDagsinntekt: Int?,
-                grad: Double?,
+                grad: Int?,
                 delytelseId: Int,
                 refDelytelseId: Int?,
                 refFagsystemId: String?,

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/OppdragInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/OppdragInspektør.kt
@@ -69,7 +69,7 @@ internal class OppdragInspektør(oppdrag: Oppdrag) : UtbetalingVisitor {
         satstype: Satstype,
         beløp: Int?,
         aktuellDagsinntekt: Int?,
-        grad: Double?,
+        grad: Int?,
         delytelseId: Int,
         refDelytelseId: Int?,
         refFagsystemId: String?,

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -270,7 +270,7 @@ internal class TestArbeidsgiverInspektør(
         satstype: Satstype,
         beløp: Int?,
         aktuellDagsinntekt: Int?,
-        grad: Double?,
+        grad: Int?,
         delytelseId: Int,
         refDelytelseId: Int?,
         refFagsystemId: String?,
@@ -297,7 +297,7 @@ internal class TestArbeidsgiverInspektør(
         val tom: LocalDate,
         val satstype: Satstype,
         val beløp: Int?,
-        val grad: Double?,
+        val grad: Int?,
         val klassekode: Klassekode,
         val endringskode: Endringskode
     )

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/TilUtbetalingHendelseTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/TilUtbetalingHendelseTest.kt
@@ -54,7 +54,7 @@ internal class TilUtbetalingHendelseTest : AbstractPersonTest() {
                             tom = 31.januar,
                             sats = 1431,
                             beløp = 1431,
-                            grad = 100.0,
+                            grad = 100,
                             sykedager = 11
                         )
                     )
@@ -106,7 +106,7 @@ internal class TilUtbetalingHendelseTest : AbstractPersonTest() {
                             tom = 31.januar,
                             sats = 1431,
                             beløp = 1431,
-                            grad = 100.0,
+                            grad = 100,
                             sykedager = 11
                         )
                     )

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/migration/V135UtbetalingslinjeGradTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/migration/V135UtbetalingslinjeGradTest.kt
@@ -1,0 +1,14 @@
+package no.nav.helse.serde.migration
+
+import org.junit.jupiter.api.Test
+
+internal class V135UtbetalingslinjeGradTest : MigrationTest(V135UtbetalingslinjeGrad()) {
+
+    @Test
+    fun `runder grad ned`() {
+        assertMigration(
+            expectedJson = "/migrations/135/expected.json",
+            originalJson = "/migrations/135/original.json"
+        )
+    }
+}

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/OverstyrTidslinjeTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/OverstyrTidslinjeTest.kt
@@ -1,7 +1,9 @@
 package no.nav.helse.spleis.e2e
 
-import no.nav.helse.hendelser.*
+import no.nav.helse.hendelser.Periode
 import no.nav.helse.hendelser.SendtSøknad.Søknadsperiode.Sykdom
+import no.nav.helse.hendelser.Sykmeldingsperiode
+import no.nav.helse.hendelser.til
 import no.nav.helse.inspectors.inspektør
 import no.nav.helse.person.Arbeidsgiver
 import no.nav.helse.person.TilstandType
@@ -104,7 +106,7 @@ internal class OverstyrTidslinjeTest : AbstractEndToEndTest() {
 
         assertEquals(3, inspektør.utbetalinger.last().inspektør.arbeidsgiverOppdrag.size)
         assertEquals(21.januar, inspektør.utbetalinger.last().inspektør.arbeidsgiverOppdrag[0].tom)
-        assertEquals(30.0, inspektør.utbetalinger.last().inspektør.arbeidsgiverOppdrag[1].grad)
+        assertEquals(30, inspektør.utbetalinger.last().inspektør.arbeidsgiverOppdrag[1].grad)
         assertEquals(23.januar, inspektør.utbetalinger.last().inspektør.arbeidsgiverOppdrag[2].fom)
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderInntektTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderInntektTest.kt
@@ -850,7 +850,7 @@ private fun Utbetalingslinje.assertUtbetalingslinje(
             satstype: Satstype,
             beløp: Int?,
             aktuellDagsinntekt: Int?,
-            grad: Double?,
+            grad: Int?,
             delytelseId: Int,
             refDelytelseId: Int?,
             refFagsystemId: String?,

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderTidslinjeTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderTidslinjeTest.kt
@@ -1371,11 +1371,11 @@ internal class RevurderTidslinjeTest : AbstractEndToEndTest() {
             assertEquals(2, oppdrag.size)
             assertEquals(18.januar, oppdrag[0].fom)
             assertEquals(25.januar, oppdrag[0].tom)
-            assertEquals(100.0, oppdrag[0].grad)
+            assertEquals(100, oppdrag[0].grad)
 
             assertEquals(26.januar, oppdrag[1].fom)
             assertEquals(26.januar, oppdrag[1].tom)
-            assertEquals(80.0, oppdrag[1].grad)
+            assertEquals(80, oppdrag[1].grad)
         }
     }
 
@@ -1411,7 +1411,7 @@ internal class RevurderTidslinjeTest : AbstractEndToEndTest() {
             assertEquals(18.januar, oppdrag[0].fom)
             assertEquals(26.januar, oppdrag[0].tom)
             assertTrue(oppdrag[0].erForskjell())
-            assertEquals(100.0, oppdrag[0].grad)
+            assertEquals(100, oppdrag[0].grad)
         }
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/UtbetalingTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/UtbetalingTest.kt
@@ -3,6 +3,7 @@ package no.nav.helse.spleis.e2e
 import no.nav.helse.hendelser.SendtSøknad.Søknadsperiode.Sykdom
 import no.nav.helse.hendelser.Sykmeldingsperiode
 import no.nav.helse.hendelser.til
+import no.nav.helse.inspectors.inspektør
 import no.nav.helse.person.infotrygdhistorikk.ArbeidsgiverUtbetalingsperiode
 import no.nav.helse.person.infotrygdhistorikk.Inntektsopplysning
 import no.nav.helse.testhelpers.februar
@@ -35,5 +36,19 @@ internal class UtbetalingTest : AbstractEndToEndTest() {
         håndterSykmelding(Sykmeldingsperiode(1.februar, 28.februar, 100.prosent))
 
         assertEquals(ORGNUMMER, observatør.utbetaltEndretEventer.single().orgnummer())
+    }
+
+    @Test
+    fun `grad rundes av`() {
+        håndterSykmelding(Sykmeldingsperiode(1.januar, 31.januar, 100.prosent))
+        håndterSøknad(Sykdom(1.januar, 31.januar, 100.prosent, 80.prosent))
+        håndterInntektsmelding(listOf(1.januar til 16.januar))
+        håndterYtelser(1.vedtaksperiode)
+        håndterVilkårsgrunnlag(1.vedtaksperiode)
+        håndterYtelser(1.vedtaksperiode)
+        håndterSimulering(1.vedtaksperiode)
+        håndterUtbetalingsgodkjenning(1.vedtaksperiode)
+        håndterUtbetalt(1.vedtaksperiode)
+        assertEquals(20, inspektør.utbetaling(0).inspektør.arbeidsgiverOppdrag[0].grad)
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/korrigering/KorrigertSøknadTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/korrigering/KorrigertSøknadTest.kt
@@ -107,7 +107,7 @@ internal class KorrigertSøknadTest : AbstractEndToEndTest() {
         håndterVilkårsgrunnlag(1.vedtaksperiode)
         håndterYtelser(1.vedtaksperiode)
         object : OppdragVisitor {
-            var grad: Double? = null
+            var grad: Int? = null
             override fun visitUtbetalingslinje(
                 linje: Utbetalingslinje,
                 fom: LocalDate,
@@ -117,7 +117,7 @@ internal class KorrigertSøknadTest : AbstractEndToEndTest() {
                 satstype: Satstype,
                 beløp: Int?,
                 aktuellDagsinntekt: Int?,
-                grad: Double?,
+                grad: Int?,
                 delytelseId: Int,
                 refDelytelseId: Int?,
                 refFagsystemId: String?,
@@ -130,7 +130,7 @@ internal class KorrigertSøknadTest : AbstractEndToEndTest() {
             }
         }.also {
             inspektør.arbeidsgiverOppdrag.first().accept(it)
-            assertEquals(50.0, it.grad)
+            assertEquals(50, it.grad)
         }
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/OppdragBuilderTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/OppdragBuilderTest.kt
@@ -110,8 +110,8 @@ internal class OppdragBuilderTest {
         val oppdrag = tilArbeidsgiver(5.NAV(1500), 1.HELG(1500), 1.HELG(1500, 80.0), 5.NAV(1500, 80.0))
 
         assertEquals(2, oppdrag.size)
-        oppdrag.assertLinje(0, 1.januar, 6.januar, null, sats = 1500, grad = 100.0)
-        oppdrag.assertLinje(1, 7.januar, 12.januar, sats = (1500 * 0.8).toInt(), grad = 80.0)
+        oppdrag.assertLinje(0, 1.januar, 6.januar, null, sats = 1500, grad = 100)
+        oppdrag.assertLinje(1, 7.januar, 12.januar, sats = (1500 * 0.8).toInt(), grad = 80)
     }
 
     @Test
@@ -303,7 +303,7 @@ internal class OppdragBuilderTest {
                 refFagsystemId = null
             ) //Opphører linje som har blitt overskrevet av nytt oppdrag
             assertLinje(2, 24.januar, 29.januar, delytelseId = 3, refDelytelseId = 2, endringskode = NY)
-            assertLinje(3, 30.januar, 2.februar, delytelseId = 4, refDelytelseId = 3, endringskode = NY, sats = 520, grad = 40.0)
+            assertLinje(3, 30.januar, 2.februar, delytelseId = 4, refDelytelseId = 3, endringskode = NY, sats = 520, grad = 40)
         }
 
         oppdragTilUtbetaling4.apply {
@@ -321,7 +321,7 @@ internal class OppdragBuilderTest {
                 datoStatusFom = 30.januar,
                 sats = 520
             )
-            assertLinje(3, 1.februar, 2.februar, delytelseId = 5, refDelytelseId = 4, endringskode = NY, sats = 520, grad = 40.0)
+            assertLinje(3, 1.februar, 2.februar, delytelseId = 5, refDelytelseId = 4, endringskode = NY, sats = 520, grad = 40)
         }
     }
 
@@ -375,8 +375,8 @@ internal class OppdragBuilderTest {
         )
 
         assertEquals(2, oppdrag.size)
-        oppdrag.assertLinje(0, 1.januar, 3.januar, null, sats = 1500, grad = 100.0)
-        oppdrag.assertLinje(1, 4.januar, 9.januar, sats = (1500 * 0.6).toInt(), grad = 60.0)
+        oppdrag.assertLinje(0, 1.januar, 3.januar, null, sats = 1500, grad = 100)
+        oppdrag.assertLinje(1, 4.januar, 9.januar, sats = (1500 * 0.6).toInt(), grad = 60)
     }
 
     @Test
@@ -388,14 +388,14 @@ internal class OppdragBuilderTest {
         )
 
         assertEquals(3, oppdrag.size)
-        oppdrag.assertLinje(0, 1.januar, 3.januar, null, sats = 1500, grad = 100.0, delytelseId = 1)
-        oppdrag.assertLinje(1, 4.januar, 5.januar, sats = 1500, grad = 80.0, delytelseId = 2, refDelytelseId = 1)
+        oppdrag.assertLinje(0, 1.januar, 3.januar, null, sats = 1500, grad = 100, delytelseId = 1)
+        oppdrag.assertLinje(1, 4.januar, 5.januar, sats = 1500, grad = 80, delytelseId = 2, refDelytelseId = 1)
         oppdrag.assertLinje(
             2,
             6.januar,
             9.januar,
             sats = (1500 * 0.8).toInt(),
-            grad = 80.0,
+            grad = 80,
             delytelseId = 3,
             refDelytelseId = 2
         )
@@ -409,8 +409,8 @@ internal class OppdragBuilderTest {
         )
 
         assertEquals(2, oppdrag.size)
-        oppdrag.assertLinje(0, 1.januar, 3.januar, null, sats = 1500, grad = 100.0)
-        oppdrag.assertLinje(1, 4.januar, 9.januar, sats = (1500 * 0.8).toInt(), grad = 80.0)
+        oppdrag.assertLinje(0, 1.januar, 3.januar, null, sats = 1500, grad = 100)
+        oppdrag.assertLinje(1, 4.januar, 9.januar, sats = (1500 * 0.8).toInt(), grad = 80)
     }
 
     @Test
@@ -450,7 +450,7 @@ internal class OppdragBuilderTest {
         val oppdrag = tilSykmeldte(16.AP, 15.NAV.medRefusjon(0))
         assertEquals(1, oppdrag.size)
         assertEquals(Fagområde.Sykepenger, oppdrag.fagområde())
-        oppdrag.assertLinje(0, 17.januar, 31.januar, null, 1200, 100.0, endringskode = NY, klassekode = Klassekode.SykepengerArbeidstakerOrdinær)
+        oppdrag.assertLinje(0, 17.januar, 31.januar, null, 1200, 100, endringskode = NY, klassekode = Klassekode.SykepengerArbeidstakerOrdinær)
     }
 
     private val Utbetalingslinje.klassekode get() = this.get<Klassekode>("klassekode")
@@ -461,7 +461,7 @@ internal class OppdragBuilderTest {
         tom: LocalDate,
         refFagsystemId: String? = this.fagsystemId(),
         sats: Int? = this[index].beløp,
-        grad: Double? = this[index].grad,
+        grad: Int? = this[index].grad,
         delytelseId: Int = this[index]["delytelseId"],
         refDelytelseId: Int? = this[index]["refDelytelseId"],
         datoStatusFom: LocalDate? = null,

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/OppdragTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/OppdragTest.kt
@@ -30,7 +30,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         val oppdrag2 = Oppdrag("mottaker", Fagområde.Sykepenger)
@@ -47,7 +47,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         val oppdrag2 = Oppdrag("mottaker", Fagområde.Sykepenger)
@@ -65,7 +65,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         val oppdrag2 = Oppdrag("mottaker", Fagområde.Sykepenger, listOf(
@@ -75,7 +75,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         oppdrag1.lagreOverføringsinformasjon(UtbetalingOverført(UUID.randomUUID(), "aktør", "fnr", "orgnr", oppdrag1.fagsystemId(), UUID.randomUUID().toString(), 1234L, LocalDateTime.now()))
@@ -91,7 +91,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         val oppdrag2 = Oppdrag("mottaker", Fagområde.Sykepenger, listOf(
@@ -101,7 +101,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         oppdrag1.lagreOverføringsinformasjon(UtbetalingOverført(UUID.randomUUID(), "aktør", "fnr", "orgnr", oppdrag1.fagsystemId(), UUID.randomUUID().toString(), 1234L, LocalDateTime.now()))
@@ -119,7 +119,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         val oppdrag2 = Oppdrag("mottaker", Fagområde.Sykepenger, listOf(
@@ -129,7 +129,7 @@ internal class OppdragTest {
                 endringskode = Endringskode.NY,
                 aktuellDagsinntekt = 1000,
                 beløp = 1000,
-                grad = 100.0
+                grad = 100
             )
         ), sisteArbeidsgiverdag = 31.desember(2017))
         oppdrag1.lagreOverføringsinformasjon(UtbetalingOverført(UUID.randomUUID(), "aktør", "fnr", "orgnr", oppdrag1.fagsystemId(), UUID.randomUUID().toString(), 1234L, LocalDateTime.now()))
@@ -155,7 +155,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.UEND,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -174,7 +174,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.UEND,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -228,7 +228,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.NY,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -248,7 +248,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.NY,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -268,7 +268,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.NY,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -302,7 +302,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.NY,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -338,7 +338,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.NY,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar
@@ -386,7 +386,7 @@ internal class OppdragTest {
                     endringskode = Endringskode.NY,
                     aktuellDagsinntekt = 1000,
                     beløp = 1000,
-                    grad = 100.0
+                    grad = 100
                 )
 
             ), sisteArbeidsgiverdag = 16.januar

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/UtbetalingslinjeForskjellTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/UtbetalingslinjeForskjellTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.util.*
+import kotlin.math.roundToInt
 
 internal class UtbetalingslinjeForskjellTest {
 
@@ -1005,13 +1006,13 @@ internal class UtbetalingslinjeForskjellTest {
     ) {
         private var delytelseId = 1
         private var endringskode: Endringskode = NY
-        private var grad: Double = 100.0
+        private var grad: Int = 100
         private var dagsats = 1200
         private var datoStatusFom: LocalDate? = null
         private var refDelytelseId: Int? = null
 
         internal infix fun grad(percentage: Number): TestUtbetalingslinje {
-            grad = percentage.toDouble()
+            grad = percentage.toDouble().roundToInt()
             return this
         }
 

--- a/sykepenger-model/src/test/resources/migrations/135/expected.json
+++ b/sykepenger-model/src/test/resources/migrations/135/expected.json
@@ -1,0 +1,45 @@
+{
+    "arbeidsgivere": [
+        {
+            "feriepengeutbetalinger": [
+                {
+                    "oppdrag": {
+                        "linjer": [
+                            {
+                                "grad": 19
+                            },
+                            {
+                                "grad": 20
+                            }
+                        ]
+                    }
+                }
+            ],
+            "utbetalinger": [
+                {
+                    "arbeidsgiverOppdrag": {
+                        "linjer": [
+                            {
+                                "grad": 19
+                            },
+                            {
+                                "grad": 20
+                            }
+                        ]
+                    },
+                    "personOppdrag": {
+                        "linjer": [
+                            {
+                                "grad": 19
+                            },
+                            {
+                                "grad": 50
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "skjemaVersjon": 135
+}

--- a/sykepenger-model/src/test/resources/migrations/135/original.json
+++ b/sykepenger-model/src/test/resources/migrations/135/original.json
@@ -1,0 +1,45 @@
+{
+    "arbeidsgivere": [
+        {
+            "feriepengeutbetalinger": [
+                {
+                    "oppdrag": {
+                        "linjer": [
+                            {
+                                "grad": 19.999999999999996
+                            },
+                            {
+                                "grad": 20.11
+                            }
+                        ]
+                    }
+                }
+            ],
+            "utbetalinger": [
+                {
+                    "arbeidsgiverOppdrag": {
+                        "linjer": [
+                            {
+                                "grad": 19.999999999999996
+                            },
+                            {
+                                "grad": 20.11
+                            }
+                        ]
+                    },
+                    "personOppdrag": {
+                        "linjer": [
+                            {
+                                "grad": 19.999999999999996
+                            },
+                            {
+                                "grad": 50.0
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "skjemaVersjon": 134
+}


### PR DESCRIPTION
fordi spenn har konvertert grad til int uten avrundning  må eksisterende utbetalingslinjer rundes ned,
fordi vi må reflektere den verdien som OS har fått.