### PR TITLE
Valider ytelser for alle perioder berørt av revurdering

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
@@ -52,8 +52,10 @@ import no.nav.helse.person.Vedtaksperiode.Companion.kanStarteRevurdering
 import no.nav.helse.person.Vedtaksperiode.Companion.medSkjæringstidspunkt
 import no.nav.helse.person.Vedtaksperiode.Companion.nåværendeVedtaksperiode
 import no.nav.helse.person.Vedtaksperiode.Companion.periode
+import no.nav.helse.person.Vedtaksperiode.Companion.skjæringstidspunktperiode
 import no.nav.helse.person.Vedtaksperiode.Companion.senerePerioderPågående
 import no.nav.helse.person.Vedtaksperiode.Companion.startRevurdering
+import no.nav.helse.person.Vedtaksperiode.Companion.validerYtelser
 import no.nav.helse.person.builders.UtbetalingsdagerBuilder
 import no.nav.helse.person.etterlevelse.MaskinellJurist
 import no.nav.helse.person.etterlevelse.SubsumsjonObserver
@@ -325,6 +327,15 @@ internal class Arbeidsgiver private constructor(
         ) {
             arbeidsgivere.forEach { it.søppelbøtte(hendelse, filter, ForkastetÅrsak.IKKE_STØTTET) }
         }
+
+        internal fun List<Arbeidsgiver>.validerYtelserForSkjæringstidspunkt(ytelser: Ytelser, skjæringstidspunkt: LocalDate, infotrygdhistorikk: Infotrygdhistorikk) {
+            forEach { it.vedtaksperioder.validerYtelser(ytelser, skjæringstidspunkt, infotrygdhistorikk) }
+        }
+
+        internal fun List<Arbeidsgiver>.skjæringstidspunktperiode(skjæringstidspunkt: LocalDate) =
+            flatMap { it.vedtaksperioder }
+                .filter { it.gjelder(skjæringstidspunkt) }
+                .skjæringstidspunktperiode(skjæringstidspunkt)
     }
 
     private fun gjenopptaBehandling(gjenopptaBehandling: IAktivitetslogg) {

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
@@ -886,12 +886,16 @@ internal class Arbeidsgiver private constructor(
 
     internal fun arbeidsgiverperiode(periode: Periode, subsumsjonObserver: SubsumsjonObserver): Arbeidsgiverperiode? {
         val arbeidsgiverperioder = person.arbeidsgiverperiodeFor(organisasjonsnummer, sykdomshistorikk.nyesteId()) ?:
-            ForkastetVedtaksperiode.arbeidsgiverperiodeFor(person, sykdomshistorikk.nyesteId(), forkastede, organisasjonsnummer, sykdomstidslinje(), periode, subsumsjonObserver)
+            ForkastetVedtaksperiode.arbeidsgiverperiodeFor(
+                person,
+                sykdomshistorikk.nyesteId(),
+                forkastede,
+                organisasjonsnummer,
+                sykdomstidslinje(),
+                subsumsjonObserver
+            )
         return arbeidsgiverperioder.finn(periode)
     }
-
-    internal fun revurderingsperiode(vedtaksperiode: Vedtaksperiode) =
-        vedtaksperioder.filter { it.avventerRevurdering() || it === vedtaksperiode }.periode()
 
     internal fun ghostPerioder(): List<GhostPeriode> = person.skjæringstidspunkterFraSpleis()
         .filter { skjæringstidspunkt -> vedtaksperioder.none { it.gjelder(skjæringstidspunkt) } }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
@@ -333,9 +333,7 @@ internal class Arbeidsgiver private constructor(
         }
 
         internal fun List<Arbeidsgiver>.skjæringstidspunktperiode(skjæringstidspunkt: LocalDate) =
-            flatMap { it.vedtaksperioder }
-                .filter { it.gjelder(skjæringstidspunkt) }
-                .skjæringstidspunktperiode(skjæringstidspunkt)
+            flatMap { it.vedtaksperioder }.skjæringstidspunktperiode(skjæringstidspunkt)
     }
 
     private fun gjenopptaBehandling(gjenopptaBehandling: IAktivitetslogg) {

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/ForkastetVedtaksperiode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/ForkastetVedtaksperiode.kt
@@ -2,7 +2,6 @@ package no.nav.helse.person
 
 import java.util.UUID
 import no.nav.helse.hendelser.Inntektsmelding
-import no.nav.helse.hendelser.Periode
 import no.nav.helse.person.Vedtaksperiode.Companion.ER_ELLER_HAR_VÆRT_AVSLUTTET
 import no.nav.helse.person.Vedtaksperiode.Companion.iderMedUtbetaling
 import no.nav.helse.person.etterlevelse.SubsumsjonObserver
@@ -58,9 +57,8 @@ internal class ForkastetVedtaksperiode(
             forkastede: List<ForkastetVedtaksperiode>,
             organisasjonsnummer: String,
             sykdomstidslinje: Sykdomstidslinje,
-            periode: Periode,
             subsumsjonObserver: SubsumsjonObserver
-        ): List<Arbeidsgiverperiode> = Vedtaksperiode.arbeidsgiverperiodeFor(person, sykdomshistorikkId, forkastede.perioder(), organisasjonsnummer, sykdomstidslinje, periode, subsumsjonObserver)
+        ): List<Arbeidsgiverperiode> = Vedtaksperiode.arbeidsgiverperiodeFor(person, sykdomshistorikkId, forkastede.perioder(), organisasjonsnummer, sykdomstidslinje, subsumsjonObserver)
 
         internal fun sjekkOmOverlapperMedForkastet(forkastede: Iterable<ForkastetVedtaksperiode>, inntektsmelding: Inntektsmelding) =
             Vedtaksperiode.sjekkOmOverlapperMedForkastet(forkastede.perioder(), inntektsmelding)

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
@@ -49,9 +49,11 @@ import no.nav.helse.person.Arbeidsgiver.Companion.kanOverstyreTidslinje
 import no.nav.helse.person.Arbeidsgiver.Companion.kanStarteRevurdering
 import no.nav.helse.person.Arbeidsgiver.Companion.nåværendeVedtaksperioder
 import no.nav.helse.person.Arbeidsgiver.Companion.rapporterteInntekter
+import no.nav.helse.person.Arbeidsgiver.Companion.skjæringstidspunktperiode
 import no.nav.helse.person.Arbeidsgiver.Companion.slettUtgåtteSykmeldingsperioder
 import no.nav.helse.person.Arbeidsgiver.Companion.startRevurdering
 import no.nav.helse.person.Arbeidsgiver.Companion.validerVilkårsgrunnlag
+import no.nav.helse.person.Arbeidsgiver.Companion.validerYtelserForSkjæringstidspunkt
 import no.nav.helse.person.Vedtaksperiode.Companion.ALLE
 import no.nav.helse.person.Vedtaksperiode.Companion.lagUtbetalinger
 import no.nav.helse.person.builders.VedtakFattetBuilder
@@ -889,4 +891,10 @@ class Person private constructor(
         arbeidsgivere.validerVilkårsgrunnlag(aktivitetslogg, vilkårsgrunnlag, skjæringstidspunkt)
         return !aktivitetslogg.hasErrorsOrWorse()
     }
+
+    internal fun validerYtelserForSkjæringstidspunkt(ytelser: Ytelser, skjæringstidspunkt: LocalDate) {
+        arbeidsgivere.validerYtelserForSkjæringstidspunkt(ytelser, skjæringstidspunkt, infotrygdhistorikk)
+    }
+
+    internal fun skjæringstidspunktperiode(skjæringstidspunkt: LocalDate) = arbeidsgivere.skjæringstidspunktperiode(skjæringstidspunkt)
 }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
@@ -327,7 +327,7 @@ class Person private constructor(
         return infotrygdhistorikk.arbeidsgiverperiodeFor(organisasjonsnummer, sykdomshistorikkId)
     }
 
-    internal fun arbeidsgiverperiodeFor(orgnummer: String, sykdomshistorikkId: UUID, sykdomstidslinje: Sykdomstidslinje, periode: Periode, subsumsjonObserver: SubsumsjonObserver): List<Arbeidsgiverperiode> {
+    internal fun arbeidsgiverperiodeFor(orgnummer: String, sykdomshistorikkId: UUID, sykdomstidslinje: Sykdomstidslinje, subsumsjonObserver: SubsumsjonObserver): List<Arbeidsgiverperiode> {
         val periodebuilder = ArbeidsgiverperiodeBuilderBuilder()
         infotrygdhistorikk.build(orgnummer, sykdomstidslinje, periodebuilder, subsumsjonObserver)
         return periodebuilder.result().also {
@@ -403,16 +403,8 @@ class Person private constructor(
         observers.forEach { it.vedtaksperiodeIkkePåminnet(påminnelse.hendelseskontekst(), tilstandType) }
     }
 
-    internal fun opprettOppgaveForSpeilsaksbehandlere(aktivitetslogg: IAktivitetslogg, event: PersonObserver.OpprettOppgaveForSpeilsaksbehandlereEvent) {
-        observers.forEach { it.opprettOppgaveForSpeilsaksbehandlere(aktivitetslogg.hendelseskontekst(), event) }
-    }
-
     internal fun opprettOppgave(aktivitetslogg: IAktivitetslogg, event: PersonObserver.OpprettOppgaveEvent) {
         observers.forEach { it.opprettOppgave(aktivitetslogg.hendelseskontekst(), event) }
-    }
-
-    internal fun utsettOppgave(aktivitetslogg: IAktivitetslogg, event: PersonObserver.UtsettOppgaveEvent) {
-        observers.forEach { it.utsettOppgave(aktivitetslogg.hendelseskontekst(), event)}
     }
 
     internal fun vedtaksperiodeForkastet(aktivitetslogg: IAktivitetslogg, event: PersonObserver.VedtaksperiodeForkastetEvent) {
@@ -541,13 +533,6 @@ class Person private constructor(
     internal fun ghostPeriode(skjæringstidspunkt: LocalDate, deaktivert: Boolean) =
         arbeidsgivere.ghostPeriode(skjæringstidspunkt, vilkårsgrunnlagHistorikk.sisteId(), deaktivert)
 
-    internal fun <T> hentArbeidsforhold(creator: (orgnummer: String, ansattFom: LocalDate, ansattTom: LocalDate?, erAktiv: Boolean) -> T) =
-        skjæringstidspunkter().associateWith { skjæringstidspunkt ->
-            arbeidsgivere.flatMap { arbeidsgiver ->
-                arbeidsgiver.arbeidsforhold(skjæringstidspunkt, creator)
-            }
-        }
-
     private fun harNærliggendeUtbetaling(periode: Periode): Boolean {
         if (infotrygdhistorikk.harBetaltRettFør(periode)) return false
         return arbeidsgivere.any { it.harNærliggendeUtbetaling(periode.oppdaterTom(periode.endInclusive.plusYears(3))) }
@@ -580,16 +565,11 @@ class Person private constructor(
 
     internal fun vilkårsgrunnlagFor(skjæringstidspunkt: LocalDate) = vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(skjæringstidspunkt)
 
-    internal fun lagreVilkårsgrunnlag(skjæringstidspunkt: LocalDate, vilkårsgrunnlag: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
+    internal fun lagreVilkårsgrunnlag(vilkårsgrunnlag: VilkårsgrunnlagHistorikk.Grunnlagsdata) {
         vilkårsgrunnlagHistorikk.lagre(vilkårsgrunnlag)
     }
 
-    internal fun lagreVilkårsgrunnlagFraInfotrygd(
-        skjæringstidspunkt: LocalDate,
-        periode: Periode,
-        hendelse: IAktivitetslogg,
-        subsumsjonObserver: SubsumsjonObserver
-    ) {
+    internal fun lagreVilkårsgrunnlagFraInfotrygd(skjæringstidspunkt: LocalDate, periode: Periode, subsumsjonObserver: SubsumsjonObserver) {
         infotrygdhistorikk.lagreVilkårsgrunnlag(skjæringstidspunkt, vilkårsgrunnlagHistorikk, ::kanOverskriveVilkårsgrunnlag) {
             beregnSykepengegrunnlagForInfotrygd(it, periode.start, subsumsjonObserver)
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
@@ -606,7 +606,7 @@ internal class Vedtaksperiode private constructor(
             person.antallArbeidsgivereMedRelevantArbeidsforhold(skjæringstidspunkt),
             jurist()
         )
-        person.lagreVilkårsgrunnlag(skjæringstidspunkt, vilkårsgrunnlag.grunnlagsdata())
+        person.lagreVilkårsgrunnlag(vilkårsgrunnlag.grunnlagsdata())
         if (vilkårsgrunnlag.hasErrorsOrWorse()) {
             return person.invaliderAllePerioder(vilkårsgrunnlag, null)
         }
@@ -1619,7 +1619,6 @@ internal class Vedtaksperiode private constructor(
                     person.lagreVilkårsgrunnlagFraInfotrygd(
                         vedtaksperiode.skjæringstidspunkt,
                         vedtaksperiode.periode(),
-                        ytelser,
                         vedtaksperiode.jurist()
                     )
                 }
@@ -2639,7 +2638,6 @@ internal class Vedtaksperiode private constructor(
             perioder: List<Vedtaksperiode>,
             organisasjonsnummer: String,
             sykdomstidslinje: Sykdomstidslinje,
-            periode: Periode,
             subsumsjonObserver: SubsumsjonObserver
         ): List<Arbeidsgiverperiode> {
             val samletSykdomstidslinje =
@@ -2648,7 +2646,6 @@ internal class Vedtaksperiode private constructor(
                 organisasjonsnummer,
                 sykdomshistorikkId,
                 samletSykdomstidslinje,
-                periode,
                 subsumsjonObserver
             )
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
@@ -498,6 +498,7 @@ internal class Vedtaksperiode private constructor(
 
     private fun validerYtelserForSkjæringstidspunkt(ytelser: Ytelser) {
         person.validerYtelserForSkjæringstidspunkt(ytelser, skjæringstidspunkt)
+        kontekst(ytelser) // resett kontekst til oss selv
     }
 
     // IM som replayes skal kunne påvirke alle perioder som er sammenhengende med replay-perioden, men også alle evt. påfølgende perioder.
@@ -1285,7 +1286,6 @@ internal class Vedtaksperiode private constructor(
                     ytelser.valider(vedtaksperiode.periode, vedtaksperiode.skjæringstidspunkt)
                 } else {
                     vedtaksperiode.validerYtelserForSkjæringstidspunkt(ytelser)
-                    vedtaksperiode.kontekst(ytelser)
                 }
                 val arbeidsgiverUtbetalinger = arbeidsgiverUtbetalingerFun(vedtaksperiode.jurist())
                 arbeidsgiver.beregn(ytelser, arbeidsgiverUtbetalinger, vedtaksperiode.periode)
@@ -1975,7 +1975,6 @@ internal class Vedtaksperiode private constructor(
     }
 
     private fun validerYtelser(ytelser: Ytelser, skjæringstidspunkt: LocalDate, infotrygdhistorikk: Infotrygdhistorikk) {
-        if (skjæringstidspunkt != this.skjæringstidspunkt) return
         kontekst(ytelser)
         tilstand.valider(this, periode, skjæringstidspunkt, arbeidsgiver, ytelser, infotrygdhistorikk)
     }
@@ -2747,11 +2746,13 @@ internal class Vedtaksperiode private constructor(
         )
 
         internal fun List<Vedtaksperiode>.validerYtelser(ytelser: Ytelser, skjæringstidspunkt: LocalDate, infotrygdhistorikk: Infotrygdhistorikk) {
-            forEach { it.validerYtelser(ytelser, skjæringstidspunkt, infotrygdhistorikk) }
+            filter { it.skjæringstidspunkt == skjæringstidspunkt }
+                .forEach { it.validerYtelser(ytelser, skjæringstidspunkt, infotrygdhistorikk) }
         }
 
         internal fun List<Vedtaksperiode>.skjæringstidspunktperiode(skjæringstidspunkt: LocalDate): Periode {
-            return skjæringstidspunkt til maxOf { it.periode.endInclusive }
+            val sisteDato = filter { it.skjæringstidspunkt == skjæringstidspunkt }.maxOf { it.periode.endInclusive }
+            return skjæringstidspunkt til sisteDato
         }
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderingV2E2ETest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/RevurderingV2E2ETest.kt
@@ -914,6 +914,9 @@ internal class RevurderingV2E2ETest : AbstractEndToEndTest() {
         håndterOverstyrTidslinje(listOf(ManuellOverskrivingDag(2.februar, Feriedag)))
         håndterYtelser(3.vedtaksperiode, foreldrepenger = 20.januar til 31.januar)
 
+        assertTilstand(1.vedtaksperiode, AVSLUTTET)
+        assertTilstand(2.vedtaksperiode, AVVENTER_GJENNOMFØRT_REVURDERING)
+        assertTilstand(3.vedtaksperiode, AVVENTER_SIMULERING_REVURDERING)
         assertNoWarnings(1.vedtaksperiode.filter())
         assertNoWarnings(2.vedtaksperiode.filter())
         assertNoWarnings(3.vedtaksperiode.filter())


### PR DESCRIPTION
I stedet for på vedtaksperiodenivå å validere ytelser/infotrygdhistorikk med én gang, så delegerer vi til vedtaksperiodens tilstand. Grunnen til det er at i eksempelet under ønsker vi ikke å validere/legge på varsel på den første perioden, når den perioden i utgangspunktet ikke er berørt av revurderingen. Ved å delegere til tilstanden til perioden, kan vi avgjøre _når_ det er aktuelt å validere. Foreløpig har jeg lagt inn at validering skjer i AvventerRevurdering, AvventerGjennomførtRevurdering og i AvventerHistorikkRevurdering. Det skal ikke være mulig at perioder som er berørt av revurderingen står i noen andre tilstander, når en eller annen periode står i AvventerHistorikkRevurdering

![image](https://user-images.githubusercontent.com/59872984/174620389-7e96394c-9738-47ff-936b-e727d34eefa3.png)
