### PR TITLE
Id på aktiviteter

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/ArbeidstakerHendelse.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/ArbeidstakerHendelse.kt
@@ -27,11 +27,11 @@ abstract class ArbeidstakerHendelse protected constructor(
     internal class FunksjonelleFeilOgVerre: AktivitetsloggVisitor {
         private val meldinger = mutableListOf<String>()
         fun meldinger() = meldinger.toList()
-        override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
+        override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
             meldinger.add(melding)
         }
 
-        override fun visitLogiskFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
+        override fun visitLogiskFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
             meldinger.add(melding)
         }
     }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -43,12 +43,12 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         delegatee.preVisitAktivitetslogg(aktivitetslogg)
     }
 
-    override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
-        delegatee.visitInfo(kontekster, aktivitet, melding, tidsstempel)
+    override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
+        delegatee.visitInfo(id, kontekster, aktivitet, melding, tidsstempel)
     }
 
-    override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
-        delegatee.visitVarsel(kontekster, aktivitet, melding, tidsstempel)
+    override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
+        delegatee.visitVarsel(id, kontekster, aktivitet, melding, tidsstempel)
     }
 
     override fun preVisitUtbetalingstidslinjeberegninger(beregninger: List<Utbetalingstidslinjeberegning>) {
@@ -215,6 +215,7 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
     }
 
     override fun visitBehov(
+        id: UUID,
         kontekster: List<SpesifikkKontekst>,
         aktivitet: Aktivitetslogg.Aktivitet.Behov,
         type: Aktivitetslogg.Aktivitet.Behov.Behovtype,
@@ -222,15 +223,15 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         detaljer: Map<String, Any?>,
         tidsstempel: String
     ) {
-        delegatee.visitBehov(kontekster, aktivitet, type, melding, detaljer, tidsstempel)
+        delegatee.visitBehov(id, kontekster, aktivitet, type, melding, detaljer, tidsstempel)
     }
 
-    override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
-        delegatee.visitFunksjonellFeil(kontekster, aktivitet, melding, tidsstempel)
+    override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
+        delegatee.visitFunksjonellFeil(id, kontekster, aktivitet, melding, tidsstempel)
     }
 
-    override fun visitLogiskFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
-        delegatee.visitLogiskFeil(kontekster, aktivitet, melding, tidsstempel)
+    override fun visitLogiskFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
+        delegatee.visitLogiskFeil(id, kontekster, aktivitet, melding, tidsstempel)
     }
 
     override fun postVisitAktivitetslogg(aktivitetslogg: Aktivitetslogg) {

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
@@ -798,6 +798,7 @@ class Person private constructor(
         val errorMeldinger = mutableListOf<String>()
         aktivitetslogg.accept(object : AktivitetsloggVisitor {
             override fun visitFunksjonellFeil(
+                id: UUID,
                 kontekster: List<SpesifikkKontekst>,
                 aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil,
                 melding: String,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/PersonData.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/PersonData.kt
@@ -384,6 +384,7 @@ internal data class PersonData(
             private val label: Char,
             private val behovtype: String?,
             private val melding: String,
+            private val id: UUID,
             private val tidsstempel: String,
             private val kontekster: List<Int>,
             private val detaljer: Map<String, Any>
@@ -391,29 +392,34 @@ internal data class PersonData(
             internal fun parseAktivitet(spesifikkKontekster: List<SpesifikkKontekst>): Aktivitetslogg.Aktivitet {
                 val kontekster = kontekster.map { index -> spesifikkKontekster[index] }
                 return when (alvorlighetsgrad) {
-                    Alvorlighetsgrad.INFO -> Aktivitetslogg.Aktivitet.Info(
+                    Alvorlighetsgrad.INFO -> Aktivitetslogg.Aktivitet.Info.gjennopprett(
+                        id,
                         kontekster,
                         melding,
                         tidsstempel
                     )
-                    Alvorlighetsgrad.WARN -> Aktivitetslogg.Aktivitet.Varsel(
+                    Alvorlighetsgrad.WARN -> Aktivitetslogg.Aktivitet.Varsel.gjennopprett(
+                        id,
                         kontekster,
                         melding,
                         tidsstempel
                     )
-                    Alvorlighetsgrad.BEHOV -> Aktivitetslogg.Aktivitet.Behov(
+                    Alvorlighetsgrad.BEHOV -> Aktivitetslogg.Aktivitet.Behov.gjennopprett(
+                        id,
                         Aktivitetslogg.Aktivitet.Behov.Behovtype.valueOf(behovtype!!),
                         kontekster,
                         melding,
                         detaljer,
                         tidsstempel
                     )
-                    Alvorlighetsgrad.ERROR -> Aktivitetslogg.Aktivitet.FunksjonellFeil(
+                    Alvorlighetsgrad.ERROR -> Aktivitetslogg.Aktivitet.FunksjonellFeil.gjennopprett(
+                        id,
                         kontekster,
                         melding,
                         tidsstempel
                     )
-                    Alvorlighetsgrad.SEVERE -> Aktivitetslogg.Aktivitet.LogiskFeil(
+                    Alvorlighetsgrad.SEVERE -> Aktivitetslogg.Aktivitet.LogiskFeil.gjennopprett(
+                        id,
                         kontekster,
                         melding,
                         tidsstempel

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/SerialisertPerson.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/SerialisertPerson.kt
@@ -94,6 +94,7 @@ import no.nav.helse.serde.migration.V171FjerneForkastedePerioderUtenSykdomstidsl
 import no.nav.helse.serde.migration.V172LoggeUbrukteVilkårsgrunnlag
 import no.nav.helse.serde.migration.V173FjerneUbrukteVilkårsgrunnlag
 import no.nav.helse.serde.migration.V174None
+import no.nav.helse.serde.migration.V175IdPåAktiviteter
 import no.nav.helse.serde.migration.V17ForkastedePerioder
 import no.nav.helse.serde.migration.V18UtbetalingstidslinjeØkonomi
 import no.nav.helse.serde.migration.V19KlippOverlappendeVedtaksperioder
@@ -371,7 +372,8 @@ class SerialisertPerson(val json: String) {
             V171FjerneForkastedePerioderUtenSykdomstidslinje(),
             V172LoggeUbrukteVilkårsgrunnlag(),
             V173FjerneUbrukteVilkårsgrunnlag(),
-            V174None()
+            V174None(),
+            V175IdPåAktiviteter()
         )
 
         fun gjeldendeVersjon() = JsonMigration.gjeldendeVersjon(migrations)

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/PeriodeVarslerBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/PeriodeVarslerBuilder.kt
@@ -17,7 +17,7 @@ internal class PeriodeVarslerBuilder(
         aktivitetslogg.accept(this)
     }
 
-    override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
+    override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
         kontekster.find { it.kontekstType == "Vedtaksperiode" }
             ?.let { it.kontekstMap["vedtaksperiodeId"] }
             ?.let(UUID::fromString)

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/migration/V175IdPåAktiviteter.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/migration/V175IdPåAktiviteter.kt
@@ -1,0 +1,15 @@
+package no.nav.helse.serde.migration
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import java.util.UUID
+
+internal class V175IdPåAktiviteter : JsonMigration(version = 175) {
+    override val description = """Legg inn unike ider på alle aktiviteter"""
+
+    override fun doMigration(jsonNode: ObjectNode, meldingerSupplier: MeldingerSupplier) {
+        val aktiviteter = jsonNode.path("aktivitetslogg").path("aktiviteter")
+        aktiviteter.forEach {
+            (it as ObjectNode).put("id", UUID.randomUUID().toString())
+        }
+    }
+}

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/reflection/AktivitetsloggMap.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/reflection/AktivitetsloggMap.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.serde.reflection
 
+import java.util.UUID
 import no.nav.helse.person.Aktivitetslogg
 import no.nav.helse.person.Aktivitetslogg.Aktivitet.Behov
 import no.nav.helse.person.Aktivitetslogg.Aktivitet.FunksjonellFeil
@@ -29,15 +30,16 @@ internal class AktivitetsloggMap(aktivitetslogg: Aktivitetslogg) : Aktivitetslog
         "kontekster" to alleKontekster.keys.toList()
     )
 
-    override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Info, melding: String, tidsstempel: String) {
-        leggTilMelding(kontekster, INFO, melding, tidsstempel)
+    override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Info, melding: String, tidsstempel: String) {
+        leggTilMelding(id, kontekster, INFO, melding, tidsstempel)
     }
 
-    override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Varsel, melding: String, tidsstempel: String) {
-        leggTilMelding(kontekster, WARN, melding, tidsstempel)
+    override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Varsel, melding: String, tidsstempel: String) {
+        leggTilMelding(id, kontekster, WARN, melding, tidsstempel)
     }
 
     override fun visitBehov(
+        id: UUID,
         kontekster: List<SpesifikkKontekst>,
         aktivitet: Behov,
         type: Behov.Behovtype,
@@ -45,20 +47,21 @@ internal class AktivitetsloggMap(aktivitetslogg: Aktivitetslogg) : Aktivitetslog
         detaljer: Map<String, Any?>,
         tidsstempel: String
     ) {
-        leggTilBehov(kontekster, BEHOV, type, melding, detaljer, tidsstempel)
+        leggTilBehov(id, kontekster, BEHOV, type, melding, detaljer, tidsstempel)
     }
 
-    override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: FunksjonellFeil, melding: String, tidsstempel: String) {
-        leggTilMelding(kontekster, ERROR, melding, tidsstempel)
+    override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: FunksjonellFeil, melding: String, tidsstempel: String) {
+        leggTilMelding(id, kontekster, ERROR, melding, tidsstempel)
     }
 
-    override fun visitLogiskFeil(kontekster: List<SpesifikkKontekst>, aktivitet: LogiskFeil, melding: String, tidsstempel: String) {
-        leggTilMelding(kontekster, SEVERE, melding, tidsstempel)
+    override fun visitLogiskFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: LogiskFeil, melding: String, tidsstempel: String) {
+        leggTilMelding(id, kontekster, SEVERE, melding, tidsstempel)
     }
 
-    private fun leggTilMelding(kontekster: List<SpesifikkKontekst>, alvorlighetsgrad: Alvorlighetsgrad, melding: String, tidsstempel: String, detaljer: Map<String, Any> = emptyMap()) {
+    private fun leggTilMelding(id: UUID, kontekster: List<SpesifikkKontekst>, alvorlighetsgrad: Alvorlighetsgrad, melding: String, tidsstempel: String, detaljer: Map<String, Any> = emptyMap()) {
         aktiviteter.add(
             mutableMapOf(
+                "id" to id.toString(),
                 "kontekster" to kontekstIndices(kontekster),
                 "alvorlighetsgrad" to alvorlighetsgrad.name,
                 "melding" to melding,
@@ -69,6 +72,7 @@ internal class AktivitetsloggMap(aktivitetslogg: Aktivitetslogg) : Aktivitetslog
     }
 
     private fun leggTilBehov(
+        id: UUID,
         kontekster: List<SpesifikkKontekst>,
         alvorlighetsgrad: Alvorlighetsgrad,
         type: Behov.Behovtype,
@@ -78,6 +82,7 @@ internal class AktivitetsloggMap(aktivitetslogg: Aktivitetslogg) : Aktivitetslog
     ) {
         aktiviteter.add(
             mutableMapOf(
+                "id" to id.toString(),
                 "kontekster" to kontekstIndices(kontekster),
                 "alvorlighetsgrad" to alvorlighetsgrad.name,
                 "behovtype" to type.toString(),

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/dsl/TestArbeidsgiverAssertions.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/dsl/TestArbeidsgiverAssertions.kt
@@ -94,7 +94,7 @@ internal class TestArbeidsgiverAssertions(private val observatør: TestObservat�
     private fun collectInfo(vararg filtre: AktivitetsloggFilter): MutableList<String> {
         val info = mutableListOf<String>()
         personInspektør.aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
+            override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
                 if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                     info.add(melding)
                 }
@@ -106,7 +106,7 @@ internal class TestArbeidsgiverAssertions(private val observatør: TestObservat�
     private fun collectVarsler(vararg filtre: AktivitetsloggFilter): MutableList<String> {
         val warnings = mutableListOf<String>()
         personInspektør.aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
+            override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
                 if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                     warnings.add(melding)
                 }
@@ -118,7 +118,7 @@ internal class TestArbeidsgiverAssertions(private val observatør: TestObservat�
     private fun collectFunksjonelleFeil(vararg filtre: AktivitetsloggFilter): MutableList<String> {
         val errors = mutableListOf<String>()
         personInspektør.aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
+            override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
                 if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                     errors.add(melding)
                 }
@@ -130,7 +130,7 @@ internal class TestArbeidsgiverAssertions(private val observatør: TestObservat�
     private fun collectLogiskeFeil(vararg filtre: AktivitetsloggFilter): MutableList<String> {
         val severes = mutableListOf<String>()
         personInspektør.aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitLogiskFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
+            override fun visitLogiskFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
                 if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                     severes.add(melding)
                 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/AktivitetsloggTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/AktivitetsloggTest.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.person
 
 import java.time.LocalDate
+import java.util.UUID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -213,7 +214,7 @@ internal class AktivitetsloggTest {
     private fun assertInfo(message: String, aktivitetslogg: Aktivitetslogg = this.aktivitetslogg) {
         var visitorCalled = false
         aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
+            override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
                 visitorCalled = true
                 assertEquals(message, melding)
             }
@@ -224,7 +225,7 @@ internal class AktivitetsloggTest {
     private fun assertVarsel(message: String, aktivitetslogg: Aktivitetslogg = this.aktivitetslogg) {
         var visitorCalled = false
         aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
+            override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
                 visitorCalled = true
                 assertEquals(message, melding)
             }
@@ -235,7 +236,7 @@ internal class AktivitetsloggTest {
     private fun assertFunksjonellFeil(message: String, aktivitetslogg: Aktivitetslogg = this.aktivitetslogg) {
         var visitorCalled = false
         aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
+            override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
                 visitorCalled = true
                 assertTrue(message in aktivitet.toString(), aktivitetslogg.toString())
             }
@@ -246,7 +247,7 @@ internal class AktivitetsloggTest {
     private fun assertLogiskFeil(message: String, aktivitetslogg: Aktivitetslogg = this.aktivitetslogg) {
         var visitorCalled = false
         aktivitetslogg.accept(object : AktivitetsloggVisitor {
-            override fun visitLogiskFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
+            override fun visitLogiskFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
                 visitorCalled = true
                 assertEquals(message, melding)
             }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/RefusjonshistorikkTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/RefusjonshistorikkTest.kt
@@ -168,7 +168,7 @@ internal class RefusjonshistorikkTest {
         val meldinger = mutableListOf<String>()
 
         accept(object : AktivitetsloggVisitor {
-            override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
+            override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
                 meldinger.add(melding)
             }
         })

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/migration/V175IdPåAktiviteterTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/migration/V175IdPåAktiviteterTest.kt
@@ -1,0 +1,21 @@
+package no.nav.helse.serde.migration
+
+import java.util.UUID
+import no.nav.helse.readResource
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class V175IdPåAktiviteterTest: MigrationTest(V175IdPåAktiviteter()) {
+
+    @Test
+    fun `aktiviteter inneholder id etter migrering`() {
+        val migrert = migrer("/migrations/175/original.json".readResource())
+        val versjon = migrert.path("skjemaVersjon").asInt()
+        val aktiviteter = migrert.path("aktivitetslogg").path("aktiviteter")
+        assertEquals(175, versjon)
+        aktiviteter.forEach {
+            assertNotNull(it.path("id"))
+            assertDoesNotThrow { UUID.fromString(it.path("id").asText()) }
+        }
+    }
+}

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/migration/V175IdPåAktiviteterTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/migration/V175IdPåAktiviteterTest.kt
@@ -2,6 +2,7 @@ package no.nav.helse.serde.migration
 
 import java.util.UUID
 import no.nav.helse.readResource
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -13,9 +14,45 @@ internal class V175IdPåAktiviteterTest: MigrationTest(V175IdPåAktiviteter()) {
         val versjon = migrert.path("skjemaVersjon").asInt()
         val aktiviteter = migrert.path("aktivitetslogg").path("aktiviteter")
         assertEquals(175, versjon)
+        assertEquals(5, aktiviteter.size())
         aktiviteter.forEach {
+            assertNotNull(it.path("kontekster"))
+            assertNotNull(it.path("melding"))
+            assertNotNull(it.path("tidsstempel"))
+            assertNotNull(it.path("detaljer"))
+            assertNotNull(it.path("alvorlighetsgrad"))
             assertNotNull(it.path("id"))
+            assertTrue(it.path("id").isTextual)
             assertDoesNotThrow { UUID.fromString(it.path("id").asText()) }
         }
     }
+
+    @Test
+    fun `tom aktivitetslogg`() {
+        assertDoesNotThrow {
+            migrer(tomAktivitetslogg)
+        }
+    }
+
+    @Test
+    fun `aktivitetslogg uten aktiviteter`() {
+        assertDoesNotThrow {
+            migrer(aktivitetsloggUtenAktiviteter)
+        }
+    }
+
+    @Language("JSON")
+    private val tomAktivitetslogg = """{
+  "skjemaVersjon": 174,
+  "aktivitetslogg": {}
+}
+    """
+    @Language("JSON")
+    private val aktivitetsloggUtenAktiviteter = """{
+  "skjemaVersjon": 174,
+  "aktivitetslogg": {
+    "aktiviteter": []
+  }
+}
+    """
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/HendelseAsserts.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/HendelseAsserts.kt
@@ -203,7 +203,7 @@ internal fun AbstractEndToEndTest.assertLogiskFeil(severe: String, vararg filtre
 private fun AbstractEndToEndTest.collectInfo(vararg filtre: AktivitetsloggFilter): MutableList<String> {
     val info = mutableListOf<String>()
     person.personLogg.accept(object : AktivitetsloggVisitor {
-        override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
+        override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
             if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                 info.add(melding)
             }
@@ -215,7 +215,7 @@ private fun AbstractEndToEndTest.collectInfo(vararg filtre: AktivitetsloggFilter
 private fun AbstractPersonTest.collectVarsler(vararg filtre: AktivitetsloggFilter): MutableList<String> {
     val warnings = mutableListOf<String>()
     person.personLogg.accept(object : AktivitetsloggVisitor {
-        override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
+        override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
             if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                 warnings.add(melding)
             }
@@ -227,7 +227,7 @@ private fun AbstractPersonTest.collectVarsler(vararg filtre: AktivitetsloggFilte
 internal fun AbstractPersonTest.collectFunksjonelleFeil(vararg filtre: AktivitetsloggFilter): MutableList<String> {
     val errors = mutableListOf<String>()
     person.personLogg.accept(object : AktivitetsloggVisitor {
-        override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
+        override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
             if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                 errors.add(melding)
             }
@@ -239,7 +239,7 @@ internal fun AbstractPersonTest.collectFunksjonelleFeil(vararg filtre: Aktivitet
 internal fun AbstractEndToEndTest.collectLogiskeFeil(vararg filtre: AktivitetsloggFilter): MutableList<String> {
     val severes = mutableListOf<String>()
     person.personLogg.accept(object : AktivitetsloggVisitor {
-        override fun visitLogiskFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
+        override fun visitLogiskFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.LogiskFeil, melding: String, tidsstempel: String) {
             if (filtre.all { filter -> kontekster.any { filter.filtrer(it) } }) {
                 severes.add(melding)
             }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingstidslinje/RefusjonsgjødslerTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingstidslinje/RefusjonsgjødslerTest.kt
@@ -386,7 +386,7 @@ internal class RefusjonsgjødslerTest {
             val meldinger = mutableListOf<String>()
 
             accept(object : AktivitetsloggVisitor {
-                override fun visitInfo(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
+                override fun visitInfo(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Info, melding: String, tidsstempel: String) {
                     meldinger.add(melding)
                 }
             })
@@ -398,7 +398,7 @@ internal class RefusjonsgjødslerTest {
             val meldinger = mutableListOf<String>()
 
             accept(object : AktivitetsloggVisitor {
-                override fun visitVarsel(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
+                override fun visitVarsel(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.Varsel, melding: String, tidsstempel: String) {
                     meldinger.add(melding)
                 }
             })
@@ -410,7 +410,7 @@ internal class RefusjonsgjødslerTest {
             val meldinger = mutableListOf<String>()
 
             accept(object : AktivitetsloggVisitor {
-                override fun visitFunksjonellFeil(kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
+                override fun visitFunksjonellFeil(id: UUID, kontekster: List<SpesifikkKontekst>, aktivitet: Aktivitetslogg.Aktivitet.FunksjonellFeil, melding: String, tidsstempel: String) {
                     meldinger.add(melding)
                 }
             })

--- a/sykepenger-model/src/test/resources/migrations/175/original.json
+++ b/sykepenger-model/src/test/resources/migrations/175/original.json
@@ -1,0 +1,74 @@
+{
+  "aktivitetslogg": {
+    "aktiviteter": [
+      {
+        "kontekster": [
+          47,
+          1,
+          10,
+          11,
+          25
+        ],
+        "alvorlighetsgrad": "INFO",
+        "melding": "En eller annen info",
+        "detaljer": {},
+        "tidsstempel": "2022-09-08 01:22:06.280"
+      },
+      {
+        "kontekster": [
+          47,
+          1,
+          10,
+          11,
+          25
+        ],
+        "alvorlighetsgrad": "BEHOV",
+        "melding": "En eller annen behov",
+        "detaljer": {},
+        "tidsstempel": "2022-09-08 01:22:06.280"
+      },
+      {
+        "kontekster": [
+          47,
+          1,
+          10,
+          11,
+          25
+        ],
+        "alvorlighetsgrad": "WARN",
+        "melding": "En eller annen warn",
+        "detaljer": {},
+        "tidsstempel": "2022-09-08 01:22:06.280"
+      },
+      {
+        "kontekster": [
+          52,
+          1,
+          10,
+          11,
+          25,
+          44
+        ],
+        "alvorlighetsgrad": "ERROR",
+        "melding": "En eller annen error",
+        "detaljer": {},
+        "tidsstempel": "2022-09-08 10:10:36.221"
+      },
+      {
+        "kontekster": [
+          52,
+          1,
+          10,
+          11,
+          25,
+          44
+        ],
+        "alvorlighetsgrad": "SEVERE",
+        "melding": "En eller annen severe",
+        "detaljer": {},
+        "tidsstempel": "2022-09-08 10:10:36.221"
+      }
+    ]
+  },
+  "skjemaVersjon": 174
+}


### PR DESCRIPTION
**Intensjon:** sporbarhet til hvert enkelt unike varsel som forberedende arbeid til varsel-epic'en. 

**Bakgrunn:** I varsel-epic'en er formålet å kunne spore at en saksbehandler har vurdert et varsel. Selve funksjonaliteten for dette bygges i Spesialist, men for sporbarhetens (og etterlevelsens) del er det hensiktsmessig at disse varslene får sin egen id allerede ved opprettelse i Spleis.