### PR TITLE
Annullere og kjøre frem

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -57,3 +57,5 @@ spec:
     value: "true"
   - name: Splarbeidsbros
     value: "true"
+  - name: ANNULLERE_OG_UTBETALE
+    value: "true"

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/Toggle.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/Toggle.kt
@@ -128,4 +128,5 @@ abstract class Toggle internal constructor(enabled: Boolean = false, private val
     object AuuHåndtererIkkeInntekt: Toggle(false)
     object OutOfOrderInnenfor18Dager: Toggle(false)
     object OutOfOrderPåvirkerSkjæringstidspunkt: Toggle(false)
+    object AnnullereOgUtbetale: Toggle("ANNULLERE_OG_UTBETALE", false)
 }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Avstemmer.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Avstemmer.kt
@@ -82,7 +82,8 @@ internal class Avstemmer(person: Person) {
             beregningId: UUID,
             overføringstidspunkt: LocalDateTime?,
             avsluttet: LocalDateTime?,
-            avstemmingsnøkkel: Long?
+            avstemmingsnøkkel: Long?,
+            annulleringer: Set<UUID>
         ) {
         }
 
@@ -120,7 +121,8 @@ internal class Avstemmer(person: Person) {
             beregningId: UUID,
             overføringstidspunkt: LocalDateTime?,
             avsluttet: LocalDateTime?,
-            avstemmingsnøkkel: Long?
+            avstemmingsnøkkel: Long?,
+            annulleringer: Set<UUID>
         ) {
             utbetalinger.add(
                 mutableMapOf<String, Any>(
@@ -220,7 +222,8 @@ internal class Avstemmer(person: Person) {
             beregningId: UUID,
             overføringstidspunkt: LocalDateTime?,
             avsluttet: LocalDateTime?,
-            avstemmingsnøkkel: Long?
+            avstemmingsnøkkel: Long?,
+            annulleringer: Set<UUID>
         ) {
             if (utbetalingstatus != Utbetalingstatus.FORKASTET) utbetalinger.getOrPut(vedtaksperiodeId) { mutableListOf() }.add(id)
         }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/DelegatedPersonVisitor.kt
@@ -987,7 +987,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         delegatee.preVisitUtbetaling(
             utbetaling,
@@ -1007,7 +1008,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             beregningId,
             overføringstidspunkt,
             avsluttet,
-            avstemmingsnøkkel
+            avstemmingsnøkkel,
+            annulleringer
         )
     }
 
@@ -1086,7 +1088,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         delegatee.postVisitUtbetaling(
             utbetaling,
@@ -1106,7 +1109,8 @@ internal class DelegatedPersonVisitor(private val delegateeFun: () -> PersonVisi
             beregningId,
             overføringstidspunkt,
             avsluttet,
-            avstemmingsnøkkel
+            avstemmingsnøkkel,
+            annulleringer
         )
     }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/JsonBuilder.kt
@@ -1292,7 +1292,8 @@ internal class JsonBuilder : AbstractBuilder() {
             beregningId: UUID,
             overføringstidspunkt: LocalDateTime?,
             avsluttet: LocalDateTime?,
-            avstemmingsnøkkel: Long?
+            avstemmingsnøkkel: Long?,
+            annulleringer: Set<UUID>
         ) {
             val utbetalingMap = mutableMapOf<String, Any?>()
             utbetalinger.add(utbetalingMap)
@@ -1357,11 +1358,13 @@ internal class JsonBuilder : AbstractBuilder() {
             beregningId: UUID,
             overføringstidspunkt: LocalDateTime?,
             avsluttet: LocalDateTime?,
-            avstemmingsnøkkel: Long?
+            avstemmingsnøkkel: Long?,
+            annulleringer: Set<UUID>
         ) {
             utbetalingMap["id"] = id
             utbetalingMap["korrelasjonsId"] = korrelasjonsId
             utbetalingMap["beregningId"] = beregningId
+            utbetalingMap["annulleringer"] = annulleringer
             utbetalingMap["utbetalingstidslinje"] = utbetalingstidslinjeMap
             utbetalingMap["arbeidsgiverOppdrag"] = arbeidsgiverOppdragMap
             utbetalingMap["personOppdrag"] = personOppdragMap
@@ -1526,7 +1529,8 @@ internal class JsonBuilder : AbstractBuilder() {
                 beregningId: UUID,
                 overføringstidspunkt: LocalDateTime?,
                 avsluttet: LocalDateTime?,
-                avstemmingsnøkkel: Long?
+                avstemmingsnøkkel: Long?,
+                annulleringer: Set<UUID>
             ) {
                 utbetalingId = id
             }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/GenerasjonerBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/GenerasjonerBuilder.kt
@@ -130,10 +130,11 @@ internal class GenerasjonerBuilder(
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         if (type != Utbetalingtype.ANNULLERING) return
-        annulleringer.leggTil(UtbetalingBuilder(utbetaling).build())
+        this.annulleringer.leggTil(UtbetalingBuilder(utbetaling).build())
     }
 
     override fun preVisitUtbetalingstidslinjeberegning(

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/UtbetalingBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/UtbetalingBuilder.kt
@@ -96,7 +96,8 @@ internal class UtbetalingerBuilder(
             beregningId: UUID,
             overføringstidspunkt: LocalDateTime?,
             avsluttet: LocalDateTime?,
-            avstemmingsnøkkel: Long?
+            avstemmingsnøkkel: Long?,
+            annulleringer: Set<UUID>
         ) {
             utbetalingId = id
 
@@ -187,7 +188,8 @@ internal class UtbetalingerBuilder(
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         if (utbetalingstatus == FORKASTET && vedtaksperiodetilstand != Vedtaksperiode.RevurderingFeilet) return
         utbetalinger.entries.find { it.value.forkastet() }?.let { utbetalinger.remove(it.key) }
@@ -222,7 +224,8 @@ internal class UtbetalingBuilder(utbetaling: InternUtbetaling) : UtbetalingVisit
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         val tidslinje = UtbetalingstidslinjeBuilder(utbetaling).build()
         val vurdering = VurderingBuilder(utbetaling).build()

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Feriepengeberegner.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Feriepengeberegner.kt
@@ -289,7 +289,8 @@ internal class Feriepengeberegner(
                 beregningId: UUID,
                 overføringstidspunkt: LocalDateTime?,
                 avsluttet: LocalDateTime?,
-                avstemmingsnøkkel: Long?
+                avstemmingsnøkkel: Long?,
+                annulleringer: Set<UUID>
             ) {
                 utbetaltUtbetaling = utbetalingstatus == Utbetalingstatus.UTBETALT
                 annullertUtbetaling = utbetalingstatus == Utbetalingstatus.ANNULLERT
@@ -362,7 +363,8 @@ internal class Feriepengeberegner(
                 beregningId: UUID,
                 overføringstidspunkt: LocalDateTime?,
                 avsluttet: LocalDateTime?,
-                avstemmingsnøkkel: Long?
+                avstemmingsnøkkel: Long?,
+                annulleringer: Set<UUID>
             ) {
                 utbetaltUtbetaling = false
             }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Utbetalingstidslinjeberegning.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/utbetalingstidslinje/Utbetalingstidslinjeberegning.kt
@@ -64,7 +64,7 @@ internal class Utbetalingstidslinjeberegning private constructor(
             gjenståendeSykedager: Int,
             type: Utbetalingtype,
             organisasjonsnummer: String
-        ): Utbetaling {
+        ): Pair<Utbetaling, List<Utbetaling>> {
             val beregning = beregnetUtbetalingstidslinjer.last()
             return Utbetaling.lagUtbetaling(
                 utbetalinger,

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/inspectors/TestArbeidsgiverInspektør.kt
@@ -312,7 +312,8 @@ internal class TestArbeidsgiverInspektør(
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         inUtbetaling = true
         if (!inVedtaksperiode) {
@@ -346,7 +347,8 @@ internal class TestArbeidsgiverInspektør(
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         inUtbetaling = false
     }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/infotrygdhistorikk/InfotrygdhistorikkTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/infotrygdhistorikk/InfotrygdhistorikkTest.kt
@@ -454,7 +454,7 @@ internal class InfotrygdhistorikkTest {
         maksdato = 1.januar,
         forbrukteSykedager = 0,
         gjenståendeSykedager = 0
-    )
+    ).first
 
     private fun historikkelement(
         perioder: List<Infotrygdperiode> = emptyList(),

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/LagUtbetalingForRevurderingTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/utbetalingslinjer/LagUtbetalingForRevurderingTest.kt
@@ -273,7 +273,7 @@ internal class LagUtbetalingForRevurderingTest {
             100,
             148,
             type
-        ).also { utbetaling ->
+        ).first.also { utbetaling ->
             utbetaling.opprett(aktivitetslogg)
             if (utbetalt) {
                 godkjenn(utbetaling)

--- a/sykepenger-utbetaling/src/main/kotlin/no/nav/helse/utbetalingslinjer/UtbetalingVisitor.kt
+++ b/sykepenger-utbetaling/src/main/kotlin/no/nav/helse/utbetalingslinjer/UtbetalingVisitor.kt
@@ -26,7 +26,8 @@ interface UtbetalingVisitor : UtbetalingsdagVisitor, OppdragVisitor, UtbetalingV
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
     }
 
@@ -55,7 +56,8 @@ interface UtbetalingVisitor : UtbetalingsdagVisitor, OppdragVisitor, UtbetalingV
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
     }
 }

--- a/sykepenger-utbetaling/src/main/kotlin/no/nav/helse/utbetalingslinjer/Utbetalingkladd.kt
+++ b/sykepenger-utbetaling/src/main/kotlin/no/nav/helse/utbetalingslinjer/Utbetalingkladd.kt
@@ -23,7 +23,8 @@ class Utbetalingkladd(
         utbetalingstidslinje: Utbetalingstidslinje,
         maksdato: LocalDate,
         forbrukteSykedager: Int,
-        gjenståendeSykedager: Int
+        gjenståendeSykedager: Int,
+        annulleringer: List<Utbetaling> = emptyList()
     ): Utbetaling {
         return Utbetaling(
             beregningId = beregningId,
@@ -35,7 +36,8 @@ class Utbetalingkladd(
             type = type,
             maksdato = maksdato,
             forbrukteSykedager = forbrukteSykedager,
-            gjenståendeSykedager = gjenståendeSykedager
+            gjenståendeSykedager = gjenståendeSykedager,
+            annulleringer = annulleringer
         )
     }
 

--- a/sykepenger-utbetaling/src/testFixtures/kotlin/no/nav/helse/inspectors/UtbetalingInspektør.kt
+++ b/sykepenger-utbetaling/src/testFixtures/kotlin/no/nav/helse/inspectors/UtbetalingInspektør.kt
@@ -69,7 +69,8 @@ class UtbetalingInspektør(utbetaling: Utbetaling) : UtbetalingVisitor {
         beregningId: UUID,
         overføringstidspunkt: LocalDateTime?,
         avsluttet: LocalDateTime?,
-        avstemmingsnøkkel: Long?
+        avstemmingsnøkkel: Long?,
+        annulleringer: Set<UUID>
     ) {
         utbetalingId = id
         this.periode = periode


### PR DESCRIPTION
Fikser:

- At to arbeidsgiverperioder kan smeltes til én (det bygges videre på ett oppdrag, det andre opphøres)
- At Infotrygd fjerner er tidligere utbetaling (som har medført at vi i Spleis har laget to oppdrag, siden UkjentDag bryter opp)
- At perioder som er stuck i prod fordi det er laget mange GodkjentUtenUtbetaling-utbetalinger hvor det egentlig bare skulle være én sammenhengende utbetaling-sak

Ligger bak toggle, og kan skrus på ved behov e.l.