### PR TITLE
lager hvite pølser for områder en arbeidsgiver ikke har fått søknad

### DIFF
--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
@@ -194,17 +194,6 @@ internal class Arbeidsgiver private constructor(
             vilkårsgrunnlag.valider(aktivitetslogg, organisasjonsnummer, relevanteArbeidsgivere)
         }
 
-        internal fun Iterable<Arbeidsgiver>.ghostPeriode(
-            skjæringstidspunkt: LocalDate,
-            vilkårsgrunnlagHistorikk: VilkårsgrunnlagHistorikk,
-            arbeidsgiver: Arbeidsgiver
-        ): GhostPeriode? {
-            val perioder = flatMap { it.vedtaksperioder.medSkjæringstidspunkt(skjæringstidspunkt).map { it.periode() } }
-            if (perioder.isEmpty()) return null
-            return vilkårsgrunnlagHistorikk.ghostPeriode(skjæringstidspunkt, arbeidsgiver.organisasjonsnummer, perioder.reduce(
-                Periode::plus))
-        }
-
         internal fun Iterable<Arbeidsgiver>.beregnFeriepengerForAlleArbeidsgivere(
             aktørId: String,
             personidentifikator: Personidentifikator,
@@ -863,10 +852,6 @@ internal class Arbeidsgiver private constructor(
         )
         return arbeidsgiverperioder.finn(periode)
     }
-
-    internal fun ghostPerioder(): List<GhostPeriode> = person.skjæringstidspunkterFraSpleis()
-        .filter { skjæringstidspunkt -> vedtaksperioder.none(MED_SKJÆRINGSTIDSPUNKT(skjæringstidspunkt)) }
-        .mapNotNull { skjæringstidspunkt -> person.ghostPeriode(skjæringstidspunkt, this) }
 
     internal fun tidligsteDato(): LocalDate {
         return sykdomstidslinje().førsteDag()

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
@@ -37,7 +37,6 @@ import no.nav.helse.hendelser.utbetaling.Utbetalingsgodkjenning
 import no.nav.helse.person.Arbeidsgiver.Companion.avklarSykepengegrunnlag
 import no.nav.helse.person.Arbeidsgiver.Companion.beregnFeriepengerForAlleArbeidsgivere
 import no.nav.helse.person.Arbeidsgiver.Companion.finn
-import no.nav.helse.person.Arbeidsgiver.Companion.ghostPeriode
 import no.nav.helse.person.Arbeidsgiver.Companion.gjenopptaBehandling
 import no.nav.helse.person.Arbeidsgiver.Companion.håndter
 import no.nav.helse.person.Arbeidsgiver.Companion.håndterOverstyrArbeidsgiveropplysninger
@@ -518,8 +517,6 @@ class Person private constructor(
     internal fun skjæringstidspunkter() =
         Arbeidsgiver.skjæringstidspunkter(arbeidsgivere, infotrygdhistorikk)
 
-    internal fun skjæringstidspunkterFraSpleis() = vilkårsgrunnlagHistorikk.skjæringstidspunkterFraSpleis()
-
     internal fun trengerHistorikkFraInfotrygd(hendelse: IAktivitetslogg, vedtaksperiode: Vedtaksperiode) {
         if (trengerHistorikkFraInfotrygd(hendelse)) return hendelse.info("Må oppfriske Infotrygdhistorikken")
         hendelse.info("Trenger ikke oppfriske Infotrygdhistorikken, bruker lagret historikk")
@@ -583,13 +580,6 @@ class Person private constructor(
 
     internal fun vedtaksperioder(filter: VedtaksperiodeFilter) = arbeidsgivere.vedtaksperioder(filter).sorted()
 
-    internal fun ghostPeriode(skjæringstidspunkt: LocalDate, arbeidsgiver: Arbeidsgiver) =
-        arbeidsgivere.ghostPeriode(
-            skjæringstidspunkt = skjæringstidspunkt,
-            vilkårsgrunnlagHistorikk = vilkårsgrunnlagHistorikk,
-            arbeidsgiver = arbeidsgiver
-        )
-
     private fun harNærliggendeUtbetaling(periode: Periode): Boolean {
         if (infotrygdhistorikk.harBetaltRettFør(periode)) return false
         return arbeidsgivere.any { it.harNærliggendeUtbetaling(periode.oppdaterTom(periode.endInclusive.plusYears(3))) }
@@ -619,9 +609,6 @@ class Person private constructor(
 
     internal fun vilkårsgrunnlagFor(skjæringstidspunkt: LocalDate) =
         vilkårsgrunnlagHistorikk.vilkårsgrunnlagFor(skjæringstidspunkt)
-
-    internal fun vilkårsgrunnlagIdFor(skjæringstidspunkt: LocalDate) =
-        vilkårsgrunnlagHistorikk.vilkårsgrunnlagIdFor(skjæringstidspunkt)
 
     internal fun blitt6GBegrensetSidenSist(skjæringstidspunkt: LocalDate) =
         vilkårsgrunnlagHistorikk.blitt6GBegrensetSidenSist(skjæringstidspunkt)

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikk.kt
@@ -67,14 +67,9 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
     internal fun vilkårsgrunnlagFor(skjæringstidspunkt: LocalDate) =
         sisteInnlag()?.vilkårsgrunnlagFor(skjæringstidspunkt)
 
-    internal fun vilkårsgrunnlagIdFor(skjæringstidspunkt: LocalDate) =
-        sisteInnlag()?.vilkårsgrunnlagIdFor(skjæringstidspunkt)
-
     internal fun avvisInngangsvilkår(tidslinjer: List<Utbetalingstidslinje>) {
         sisteInnlag()?.avvis(tidslinjer)
     }
-
-    internal fun skjæringstidspunkterFraSpleis() = sisteInnlag()?.skjæringstidspunkterFraSpleis() ?: emptySet()
 
     internal fun medInntekt(organisasjonsnummer: String, dato: LocalDate, økonomi: Økonomi, arbeidsgiverperiode: Arbeidsgiverperiode?, regler: ArbeidsgiverRegler, subsumsjonObserver: SubsumsjonObserver) =
         sisteInnlag()!!.medInntekt(organisasjonsnummer, dato, økonomi, arbeidsgiverperiode, regler, subsumsjonObserver)
@@ -88,10 +83,6 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
     internal fun blitt6GBegrensetSidenSist(skjæringstidspunkt: LocalDate): Boolean {
         if (sisteInnlag()?.vilkårsgrunnlagFor(skjæringstidspunkt)?.er6GBegrenset() == false) return false
         return forrigeInnslag()?.vilkårsgrunnlagFor(skjæringstidspunkt)?.er6GBegrenset() == false
-    }
-
-    internal fun ghostPeriode(skjæringstidspunkt: LocalDate, organisasjonsnummer: String, periode: Periode): GhostPeriode? {
-        return vilkårsgrunnlagFor(skjæringstidspunkt)?.ghostPeriode(sisteId(), organisasjonsnummer, periode)
     }
 
     internal class Innslag private constructor(
@@ -123,13 +114,6 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
 
         internal fun vilkårsgrunnlagFor(skjæringstidspunkt: LocalDate) =
             vilkårsgrunnlag[skjæringstidspunkt]
-
-        internal fun vilkårsgrunnlagIdFor(skjæringstidspunkt: LocalDate) =
-            vilkårsgrunnlag[skjæringstidspunkt]?.id()
-
-        internal fun skjæringstidspunkterFraSpleis() = vilkårsgrunnlag
-            .filterValues { it is Grunnlagsdata }
-            .keys
 
         internal fun avvis(tidslinjer: List<Utbetalingstidslinje>) {
             val skjæringstidspunktperioder = skjæringstidspunktperioder(vilkårsgrunnlag.values)
@@ -229,8 +213,6 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         }
         internal fun inntektskilde() = sykepengegrunnlag.inntektskilde()
 
-        internal fun id() = vilkårsgrunnlagId
-
         internal open fun avvis(tidslinjer: List<Utbetalingstidslinje>, skjæringstidspunktperiode: Periode) {}
 
         final override fun toSpesifikkKontekst() = SpesifikkKontekst(
@@ -302,8 +284,6 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
 
         internal fun refusjonsopplysninger(organisasjonsnummer: String) =
             sykepengegrunnlag.refusjonsopplysninger(organisasjonsnummer)
-
-        internal abstract fun ghostPeriode(sisteId: UUID, organisasjonsnummer: String, periode: Periode): GhostPeriode?
 
         internal fun inntekt(organisasjonsnummer: String): Inntekt? =
             sykepengegrunnlag.inntekt(organisasjonsnummer)
@@ -414,10 +394,6 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
             return !aktivitetslogg.harFunksjonelleFeilEllerVerre()
         }
 
-        override fun ghostPeriode(sisteId: UUID, organisasjonsnummer: String, periode: Periode): GhostPeriode? {
-            return sykepengegrunnlag.ghostPeriode(sisteId, vilkårsgrunnlagId, organisasjonsnummer, periode)
-        }
-
         override fun accept(vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {
             vilkårsgrunnlagHistorikkVisitor.preVisitGrunnlagsdata(
                 skjæringstidspunkt,
@@ -494,8 +470,6 @@ internal class VilkårsgrunnlagHistorikk private constructor(private val histori
         sykepengegrunnlag: Sykepengegrunnlag,
         vilkårsgrunnlagId: UUID = UUID.randomUUID()
     ) : VilkårsgrunnlagElement(vilkårsgrunnlagId, skjæringstidspunkt, sykepengegrunnlag, null) {
-
-        override fun ghostPeriode(sisteId: UUID, organisasjonsnummer: String, periode: Periode) = null
 
         override fun overstyrArbeidsforhold(
             hendelse: OverstyrArbeidsforhold,

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/inntekt/ArbeidsgiverInntektsopplysning.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/inntekt/ArbeidsgiverInntektsopplysning.kt
@@ -66,10 +66,6 @@ class ArbeidsgiverInntektsopplysning(
         return result
     }
 
-    internal fun ikkeGhost(): Boolean {
-        return inntektsopplysning is Inntektsmelding
-    }
-
     internal companion object {
         internal fun List<ArbeidsgiverInntektsopplysning>.deaktiver(deaktiverte: List<ArbeidsgiverInntektsopplysning>, orgnummer: String, forklaring: String, subsumsjonObserver: SubsumsjonObserver) =
             this.fjernInntekt(deaktiverte, orgnummer, forklaring, true, subsumsjonObserver)

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/inntekt/Sykepengegrunnlag.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/inntekt/Sykepengegrunnlag.kt
@@ -303,21 +303,6 @@ internal class Sykepengegrunnlag(
 
     internal fun er6GBegrenset() = begrensning == ER_6G_BEGRENSET
 
-    internal fun ghostPeriode(sisteId: UUID, vilkårsgrunnlagId: UUID, organisasjonsnummer: String, periode: Periode): GhostPeriode? {
-        val opplysning = arbeidsgiverInntektsopplysninger.firstOrNull { it.gjelder(organisasjonsnummer) }
-            ?: deaktiverteArbeidsforhold.firstOrNull { it.gjelder(organisasjonsnummer) }
-        if (opplysning == null || opplysning.ikkeGhost()) return null
-        val erDeaktivert = deaktiverteArbeidsforhold.any { it === opplysning }
-        return GhostPeriode(
-            fom = periode.start,
-            tom = periode.endInclusive,
-            skjæringstidspunkt = skjæringstidspunkt,
-            vilkårsgrunnlagHistorikkInnslagId = sisteId,
-            vilkårsgrunnlagId = vilkårsgrunnlagId,
-            deaktivert = erDeaktivert
-        )
-    }
-
     internal fun finnEndringsdato(other: Sykepengegrunnlag): LocalDate {
         check(this.skjæringstidspunkt == other.skjæringstidspunkt) {
             "Skal bare sammenlikne med samme skjæringstidspunkt"

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/ArbeidsgiverBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/ArbeidsgiverBuilder.kt
@@ -15,30 +15,10 @@ internal class ArbeidsgiverBuilder(
     private val organisasjonsnummer: String
 ) : BuilderState() {
 
-    companion object {
-        internal fun List<ArbeidsgiverDTO>.vilkårsgrunnlagSomPekesPåAvGhostPerioder(): Map<UUID, Vilkårsgrunnlag> {
-            return flatMap { it.ghostPerioder }
-                .filter { it.vilkårsgrunnlagId != null && it.vilkårsgrunnlag != null }
-                .associate { it.vilkårsgrunnlagId!! to it.vilkårsgrunnlag!! }
-        }
-    }
-
     internal fun build(hendelser: List<HendelseDTO>, alder: Alder, vilkårsgrunnlagHistorikk: IVilkårsgrunnlagHistorikk): ArbeidsgiverDTO {
         return ArbeidsgiverDTO(
             organisasjonsnummer = organisasjonsnummer,
             id = id,
-            ghostPerioder = arbeidsgiver.ghostPerioder().map {
-                GhostPeriodeDTO(
-                    id = UUID.randomUUID(),
-                    fom = it.fom.coerceAtLeast(it.skjæringstidspunkt),
-                    tom = it.tom,
-                    skjæringstidspunkt = it.skjæringstidspunkt,
-                    vilkårsgrunnlagHistorikkInnslagId = it.vilkårsgrunnlagHistorikkInnslagId,
-                    vilkårsgrunnlagId = it.vilkårsgrunnlagId,
-                    vilkårsgrunnlag = vilkårsgrunnlagHistorikk.finn(it.vilkårsgrunnlagHistorikkInnslagId, it.vilkårsgrunnlagId, it.skjæringstidspunkt),
-                    deaktivert = it.deaktivert
-                )
-            },
             generasjoner = GenerasjonerBuilder(hendelser, alder, arbeidsgiver, vilkårsgrunnlagHistorikk).build()
         )
     }

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/PersonBuilder.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/serde/api/speil/builders/PersonBuilder.kt
@@ -11,7 +11,6 @@ import no.nav.helse.serde.AbstractBuilder
 import no.nav.helse.serde.api.BuilderState
 import no.nav.helse.serde.api.dto.HendelseDTO
 import no.nav.helse.serde.api.dto.PersonDTO
-import no.nav.helse.serde.api.speil.builders.ArbeidsgiverBuilder.Companion.vilkårsgrunnlagSomPekesPåAvGhostPerioder
 import no.nav.helse.Alder
 
 internal class PersonBuilder(
@@ -30,8 +29,10 @@ internal class PersonBuilder(
         val vilkårsgrunnlagHistorikk = VilkårsgrunnlagBuilder(vilkårsgrunnlagHistorikk).build()
         val arbeidsgivere = arbeidsgivere
             .map { it.build(hendelser, alder, vilkårsgrunnlagHistorikk) }
+            .let { arbeidsgivere ->
+                arbeidsgivere.map { it.medGhostperioder(vilkårsgrunnlagHistorikk, arbeidsgivere) }
+            }
             .filterNot { it.erTom(vilkårsgrunnlagHistorikk) }
-        val vilkårsgrunnlag = arbeidsgivere.vilkårsgrunnlagSomPekesPåAvGhostPerioder() + vilkårsgrunnlagHistorikk.vilkårsgrunnlagSomPekesPåAvBeregnedePerioder()
 
         return PersonDTO(
             fødselsnummer = personidentifikator.toString(),
@@ -39,7 +40,7 @@ internal class PersonBuilder(
             arbeidsgivere = arbeidsgivere,
             dødsdato = dødsdato,
             versjon = versjon,
-            vilkårsgrunnlag = vilkårsgrunnlag
+            vilkårsgrunnlag = vilkårsgrunnlagHistorikk.vilkårsgrunnlagSomBlirPektPå()
         )
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/person/VilkårsgrunnlagHistorikkInnslagTest.kt
@@ -168,8 +168,6 @@ internal class VilkårsgrunnlagHistorikkInnslagTest {
             override fun accept(vilkårsgrunnlagHistorikkVisitor: VilkårsgrunnlagHistorikkVisitor) {}
             override fun vilkårsgrunnlagtype() = "testgrunnlag"
 
-            override fun ghostPeriode(sisteId: UUID, organisasjonsnummer: String, periode: Periode) = null
-
             override fun overstyrArbeidsforhold(
                 hendelse: OverstyrArbeidsforhold,
                 subsumsjonObserver: SubsumsjonObserver

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/GenerasjonerBuilderTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/GenerasjonerBuilderTest.kt
@@ -32,7 +32,6 @@ import no.nav.helse.mai
 import no.nav.helse.mars
 import no.nav.helse.november
 import no.nav.helse.oktober
-import no.nav.helse.person.TilstandType
 import no.nav.helse.person.TilstandType.AVSLUTTET
 import no.nav.helse.person.TilstandType.AVSLUTTET_UTEN_UTBETALING
 import no.nav.helse.person.TilstandType.AVVENTER_BLOKKERENDE_PERIODE
@@ -47,7 +46,6 @@ import no.nav.helse.person.TilstandType.AVVENTER_VILKÅRSPRØVING
 import no.nav.helse.person.TilstandType.REVURDERING_FEILET
 import no.nav.helse.person.TilstandType.TIL_INFOTRYGD
 import no.nav.helse.person.TilstandType.TIL_UTBETALING
-import no.nav.helse.person.aktivitetslogg.Varselkode
 import no.nav.helse.person.arbeidsgiver
 import no.nav.helse.person.nullstillTilstandsendringer
 import no.nav.helse.serde.api.dto.BeregnetPeriode
@@ -84,7 +82,6 @@ import no.nav.helse.spleis.e2e.assertForkastetPeriodeTilstander
 import no.nav.helse.spleis.e2e.assertSisteTilstand
 import no.nav.helse.spleis.e2e.assertTilstand
 import no.nav.helse.spleis.e2e.assertTilstander
-import no.nav.helse.spleis.e2e.assertVarsel
 import no.nav.helse.spleis.e2e.forkastAlle
 import no.nav.helse.spleis.e2e.forlengVedtak
 import no.nav.helse.spleis.e2e.håndterAnnullerUtbetaling
@@ -105,7 +102,6 @@ import no.nav.helse.spleis.e2e.søknadDTOer
 import no.nav.helse.spleis.e2e.tilGodkjenning
 import no.nav.helse.testhelpers.inntektperioderForSammenligningsgrunnlag
 import no.nav.helse.testhelpers.inntektperioderForSykepengegrunnlag
-import no.nav.helse.utbetalingslinjer.Endringskode
 import no.nav.helse.utbetalingslinjer.Oppdragstatus
 import no.nav.helse.økonomi.Inntekt.Companion.månedlig
 import no.nav.helse.økonomi.Prosentdel.Companion.prosent
@@ -1980,7 +1976,7 @@ internal class GenerasjonerBuilderTest : AbstractEndToEndTest() {
             vilkårsgrunnlagHistorikkBuilderResult
         )
         val generasjoner = generasjonerBuilder.build()
-        vilkårsgrunnlag = vilkårsgrunnlagHistorikkBuilderResult.vilkårsgrunnlagSomPekesPåAvBeregnedePerioder()
+        vilkårsgrunnlag = vilkårsgrunnlagHistorikkBuilderResult.vilkårsgrunnlagSomBlirPektPå()
         return generasjoner
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilderNyTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/VilkårsgrunnlagBuilderNyTest.kt
@@ -65,7 +65,7 @@ internal class VilkårsgrunnlagBuilderNyTest : AbstractEndToEndTest() {
             person.arbeidsgiver(organisasjonsnummer),
             vilkårsgrunnlagHistorikkBuilderResult
         ).build()
-        return vilkårsgrunnlagHistorikkBuilderResult.vilkårsgrunnlagSomPekesPåAvBeregnedePerioder()
+        return vilkårsgrunnlagHistorikkBuilderResult.vilkårsgrunnlagSomBlirPektPå()
     }
 
     private val primitivInntekt = 40000.0

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/revurdering/RevurderInntektTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/revurdering/RevurderInntektTest.kt
@@ -122,7 +122,7 @@ internal class RevurderInntektTest : AbstractEndToEndTest() {
 
         val beregning = inspektør.utbetalingstidslinjeberegningData.last()
 
-        assertEquals(beregning.vilkårsgrunnlagHistorikkInnslagId, person.nyesteIdForVilkårsgrunnlagHistorikk())
+        assertEquals(beregning.vilkårsgrunnlagHistorikkInnslagId, person.inspektør.vilkårsgrunnlagHistorikkInnslag().first().inspektør.id)
 
         val vilkårsgrunnlagInspektør = inspektør.vilkårsgrunnlag(1.vedtaksperiode)?.inspektør
         val sykepengegrunnlagInspektør = vilkårsgrunnlagInspektør?.sykepengegrunnlag?.inspektør


### PR DESCRIPTION
i flere arbeidsgivere-situasjon så fylles tidslinjene til arbeidsgiverne ut med arbeidsdager, aka "forventede dager", som gjør at beregning av flere AG + ghosts faktisk funker.

Dagens hvite pølser støtter bare én pølse per arbeidsgiver, og den forsvinner med en gang arbeidsgiveren får en søknad.

Med denne endringen så lager vi potensielt mange hvite pølser, og tetter alle hulrom på en arbeidsgiver.

Hvite pølser !== arbeidsgiveren er ghost