### PR TITLE
alle forkastede perioder går til infotrygd

### DIFF
--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverMediatorTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/e2e/KunEnArbeidsgiverMediatorTest.kt
@@ -185,7 +185,8 @@ internal class KunEnArbeidsgiverMediatorTest : AbstractEndToEndMediatorTest() {
             "AVVENTER_SIMULERING",
             "AVVENTER_GODKJENNING",
             "TIL_UTBETALING",
-            "AVSLUTTET"
+            "AVSLUTTET",
+            "TIL_INFOTRYGD"
         )
     }
 

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Vedtaksperiode.kt
@@ -482,8 +482,7 @@ internal class Vedtaksperiode private constructor(
         hendelse.info("Forkaster vedtaksperiode: %s", this.id.toString())
         this.utbetalinger.forkast(hendelse)
         val vedtaksperiodeForkastetEventBuilder = VedtaksperiodeForkastetEventBuilder(tilstand.type)
-        // TODO: Speilbuilder må støtte å vise røde pølser dersom perioden er TIL_INFOTRYGD og utbetalingen er annullert, og ignorerer infotrygdpølser uten utbetaling
-        if (!this.utbetalinger.harAvsluttede()) tilstand(hendelse, TilInfotrygd)
+        tilstand(hendelse, TilInfotrygd)
         return vedtaksperiodeForkastetEventBuilder
     }
 

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/GenerasjonerBuilderTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/serde/api/v2/buildere/GenerasjonerBuilderTest.kt
@@ -1284,7 +1284,7 @@ internal class GenerasjonerBuilderTest : AbstractEndToEndTest() {
         håndterAnnullerUtbetaling()
         håndterUtbetalt()
 
-        assertTilstand(1.vedtaksperiode, REVURDERING_FEILET)
+        assertTilstand(1.vedtaksperiode, TIL_INFOTRYGD)
 
         assertEquals(3, generasjoner.size)
         0.generasjon {

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/AnnullerUtbetalingTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/AnnullerUtbetalingTest.kt
@@ -169,7 +169,7 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
         håndterUtbetalt(status = Oppdragstatus.FEIL)
         assertFalse(hendelselogg.harFunksjonelleFeilEllerVerre())
         assertEquals(Utbetalingstatus.OVERFØRT, inspektør.utbetaling(1).inspektør.tilstand)
-        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET)
+        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET, TIL_INFOTRYGD)
     }
 
     @Test
@@ -180,7 +180,7 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
         håndterUtbetalt(status = Oppdragstatus.AVVIST)
         assertFalse(person.personLogg.harFunksjonelleFeilEllerVerre())
         assertEquals(Utbetalingstatus.OVERFØRT, inspektør.utbetaling(1).inspektør.tilstand)
-        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET)
+        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET, TIL_INFOTRYGD)
     }
 
     @Test
@@ -192,7 +192,7 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
         håndterAnnullerUtbetaling(fagsystemId = inspektør.fagsystemId(1.vedtaksperiode))
         assertFalse(person.personLogg.harFunksjonelleFeilEllerVerre(), person.personLogg.toString())
         inspektør.also {
-            assertEquals(AVSLUTTET, inspektør.sisteTilstand(1.vedtaksperiode))
+            assertEquals(TIL_INFOTRYGD, inspektør.sisteTilstand(1.vedtaksperiode))
             assertTrue(inspektør.periodeErForkastet(1.vedtaksperiode))
         }
     }
@@ -209,8 +209,8 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
         assertEquals(Utbetalingstatus.OVERFØRT, inspektør.utbetaling(2).inspektør.tilstand)
         assertEquals(Utbetalingtype.ANNULLERING, inspektør.utbetaling(2).inspektør.type)
         håndterUtbetalt(status = Oppdragstatus.AKSEPTERT)
-        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET)
-        assertForkastetPeriodeTilstander(2.vedtaksperiode, AVSLUTTET)
+        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET, TIL_INFOTRYGD)
+        assertForkastetPeriodeTilstander(2.vedtaksperiode, AVSLUTTET, TIL_INFOTRYGD)
         assertForkastetPeriodeTilstander(3.vedtaksperiode, AVVENTER_HISTORIKK, TIL_INFOTRYGD)
         assertEquals(Utbetalingstatus.ANNULLERT, inspektør.utbetaling(2).inspektør.tilstand)
     }
@@ -222,7 +222,7 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
         håndterAnnullerUtbetaling()
         håndterUtbetalt(status = Oppdragstatus.AKSEPTERT)
         assertFalse(person.personLogg.harFunksjonelleFeilEllerVerre(), person.personLogg.toString())
-        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET)
+        assertForkastetPeriodeTilstander(1.vedtaksperiode, AVSLUTTET, TIL_INFOTRYGD)
     }
 
     @Test
@@ -237,7 +237,7 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
         assertEquals(1, person.personLogg.behov().size - behovTeller, person.personLogg.toString())
         assertTilstander(1.vedtaksperiode, AVSLUTTET)
         assertTilstander(2.vedtaksperiode, AVSLUTTET)
-        assertForkastetPeriodeTilstander(3.vedtaksperiode, AVSLUTTET)
+        assertForkastetPeriodeTilstander(3.vedtaksperiode, AVSLUTTET, TIL_INFOTRYGD)
     }
 
     @Test
@@ -277,8 +277,8 @@ internal class AnnullerUtbetalingTest : AbstractEndToEndTest() {
             status = Oppdragstatus.AKSEPTERT
         )
 
-        assertEquals(AVSLUTTET, inspektør.sisteTilstand(1.vedtaksperiode))
-        assertEquals(AVSLUTTET, inspektør.sisteTilstand(2.vedtaksperiode))
+        assertEquals(TIL_INFOTRYGD, inspektør.sisteTilstand(1.vedtaksperiode))
+        assertEquals(TIL_INFOTRYGD, inspektør.sisteTilstand(2.vedtaksperiode))
 
         val annulleringer = observatør.annulleringer
         assertEquals(1, annulleringer.size)

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/UtbetalingOgAnnulleringTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/UtbetalingOgAnnulleringTest.kt
@@ -107,7 +107,8 @@ internal class UtbetalingOgAnnulleringTest : AbstractEndToEndTest() {
             AVVENTER_SIMULERING,
             AVVENTER_GODKJENNING,
             TIL_UTBETALING,
-            AVSLUTTET
+            AVSLUTTET,
+            TIL_INFOTRYGD
         )
 
         assertForkastetPeriodeTilstander(

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/VedtaksperiodeForkastetE2ETest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/VedtaksperiodeForkastetE2ETest.kt
@@ -53,6 +53,6 @@ internal class VedtaksperiodeForkastetE2ETest : AbstractEndToEndTest() {
         assertEquals(AVSLUTTET, observatør.forkastet(3.vedtaksperiode.id(ORGNUMMER)).gjeldendeTilstand)
         assertSisteTilstand(1.vedtaksperiode, AVSLUTTET_UTEN_UTBETALING)
         assertSisteTilstand(2.vedtaksperiode, AVSLUTTET_UTEN_UTBETALING)
-        assertSisteTilstand(3.vedtaksperiode, AVSLUTTET)
+        assertSisteTilstand(3.vedtaksperiode, TIL_INFOTRYGD)
     }
 }

--- a/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/revurdering/RevurderTidslinjeTest.kt
+++ b/sykepenger-model/src/test/kotlin/no/nav/helse/spleis/e2e/revurdering/RevurderTidslinjeTest.kt
@@ -19,23 +19,8 @@ import no.nav.helse.mai
 import no.nav.helse.mars
 import no.nav.helse.november
 import no.nav.helse.person.IdInnhenter
-import no.nav.helse.person.TilstandType.AVSLUTTET
-import no.nav.helse.person.TilstandType.AVVENTER_BLOKKERENDE_PERIODE
-import no.nav.helse.person.TilstandType.AVVENTER_GJENNOMFØRT_REVURDERING
-import no.nav.helse.person.TilstandType.AVVENTER_GODKJENNING
-import no.nav.helse.person.TilstandType.AVVENTER_GODKJENNING_REVURDERING
-import no.nav.helse.person.TilstandType.AVVENTER_HISTORIKK
-import no.nav.helse.person.TilstandType.AVVENTER_HISTORIKK_REVURDERING
-import no.nav.helse.person.TilstandType.AVVENTER_INFOTRYGDHISTORIKK
-import no.nav.helse.person.TilstandType.AVVENTER_INNTEKTSMELDING
-import no.nav.helse.person.TilstandType.AVVENTER_REVURDERING
-import no.nav.helse.person.TilstandType.AVVENTER_SIMULERING
-import no.nav.helse.person.TilstandType.AVVENTER_SIMULERING_REVURDERING
-import no.nav.helse.person.TilstandType.AVVENTER_VILKÅRSPRØVING
-import no.nav.helse.person.TilstandType.AVVENTER_VILKÅRSPRØVING_REVURDERING
-import no.nav.helse.person.TilstandType.REVURDERING_FEILET
-import no.nav.helse.person.TilstandType.START
-import no.nav.helse.person.TilstandType.TIL_UTBETALING
+import no.nav.helse.person.TilstandType
+import no.nav.helse.person.TilstandType.*
 import no.nav.helse.person.aktivitetslogg.Aktivitet
 import no.nav.helse.person.aktivitetslogg.Varselkode
 import no.nav.helse.person.aktivitetslogg.Varselkode.RV_IT_1
@@ -174,8 +159,8 @@ internal class RevurderTidslinjeTest : AbstractEndToEndTest() {
         håndterUtbetalingsgodkjenning(2.vedtaksperiode, utbetalingGodkjent = false)
         nullstillTilstandsendringer()
         håndterAnnullerUtbetaling(fagsystemId = inspektør.utbetaling(1).inspektør.arbeidsgiverOppdrag.inspektør.fagsystemId())
-        assertForkastetPeriodeTilstander(1.vedtaksperiode, REVURDERING_FEILET)
-        assertForkastetPeriodeTilstander(2.vedtaksperiode, REVURDERING_FEILET)
+        assertForkastetPeriodeTilstander(1.vedtaksperiode, REVURDERING_FEILET, TIL_INFOTRYGD)
+        assertForkastetPeriodeTilstander(2.vedtaksperiode, REVURDERING_FEILET, TIL_INFOTRYGD)
     }
 
     @Test
@@ -805,7 +790,8 @@ internal class RevurderTidslinjeTest : AbstractEndToEndTest() {
             AVVENTER_REVURDERING,
             AVVENTER_GJENNOMFØRT_REVURDERING,
             AVVENTER_HISTORIKK_REVURDERING,
-            AVVENTER_SIMULERING_REVURDERING
+            AVVENTER_SIMULERING_REVURDERING,
+            TIL_INFOTRYGD
         )
     }
 


### PR DESCRIPTION
annulleringspølser bygges nå uavhengig av hvilken tilstand forkastede perioder er i, og vi kan derfor begynne å kaste alt Til infotrygd når ting går ut