### PR TITLE
ci: NAIS kommer med breaking changes i action

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -33,6 +33,7 @@ jobs:
           team: tbd
           image_suffix: spleis
           tag: "${{ github.ref_name }}-${{ github.sha }}"
+          dockerfile: Dockerfile
           docker_context: sykepenger-mediators
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
nais/docker-build-push endrer `dockerfile`-feltet til å få prefixet `docker_context`. Dette er slik underliggende `docker/build-push-action` oppfører seg, så målet er å bli likere den.