### PR TITLE
ci: NAIS kommer med breaking changes i action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           team: tbd
           image_suffix: spleis
+          dockerfile: Dockerfile
           docker_context: sykepenger-mediators
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
nais/docker-build-push endrer `dockerfile`-feltet til å få prefixet `docker_context`. Dette er slik underliggende `docker/build-push-action` oppfører seg, så målet er å bli likere den.