### PR TITLE
legger på auuer i forkant på godkjenningsbehovet

### DIFF
--- a/sykepenger-aktivitetslogg/src/main/kotlin/no/nav/helse/person/aktivitetslogg/GodkjenningsbehovBuilder.kt
+++ b/sykepenger-aktivitetslogg/src/main/kotlin/no/nav/helse/person/aktivitetslogg/GodkjenningsbehovBuilder.kt
@@ -14,6 +14,7 @@ class GodkjenningsbehovBuilder(
     periode: ClosedRange<LocalDate>,
     private val behandlingId: UUID,
     private val perioderMedSammeSkjæringstidspunkt: List<PeriodeMedSammeSkjæringstidspunkt>,
+    private val auuerIForkant: List<UUID>,
     private val hendelser: Set<UUID>
 ) {
     private val tags: MutableSet<String> = mutableSetOf()
@@ -132,6 +133,7 @@ class GodkjenningsbehovBuilder(
                     "tom" to it.periode.endInclusive.toString()
                 )
             },
+            "auuerIForkant" to auuerIForkant,
             "sykepengegrunnlagsfakta" to when (sykepengegrunnlagsfakta) {
                 is FastsattIInfotrygd -> mapOf(
                     "omregnetÅrsinntektTotalt" to sykepengegrunnlagsfakta.omregnetÅrsinntektTotalt,

--- a/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/mediator/e2e/BehovkontraktTest.kt
+++ b/sykepenger-mediators/src/test/kotlin/no/nav/helse/spleis/mediator/e2e/BehovkontraktTest.kt
@@ -249,6 +249,7 @@ internal class BehovkontraktTest : AbstractEndToEndMediatorTest() {
         assertTrue(godkjenning.path("omregnedeÅrsinntekter").path(0).path("beløp").isDouble)
         assertTrue(godkjenning.path("behandlingId").asText().isNotEmpty())
         assertTrue(godkjenning.path("perioderMedSammeSkjæringstidspunkt").isArray)
+        assertTrue(godkjenning.path("auuerIForkant").isArray)
         assertFalse(godkjenning.path("perioderMedSammeSkjæringstidspunkt").isEmpty)
         godkjenning.path("perioderMedSammeSkjæringstidspunkt").path(0).also {
             assertTrue(it.path("vedtaksperiodeId").asText().isNotEmpty())

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Arbeidsgiver.kt
@@ -41,6 +41,7 @@ import no.nav.helse.person.Vedtaksperiode.Companion.SKAL_INNGÅ_I_SYKEPENGEGRUNN
 import no.nav.helse.person.Vedtaksperiode.Companion.aktiveSkjæringstidspunkter
 import no.nav.helse.person.Vedtaksperiode.Companion.beregnSkjæringstidspunkter
 import no.nav.helse.person.Vedtaksperiode.Companion.checkBareEnPeriodeTilGodkjenningSamtidig
+import no.nav.helse.person.Vedtaksperiode.Companion.finnAuuerIForkant
 import no.nav.helse.person.Vedtaksperiode.Companion.førsteOverlappendePeriodeSomTrengerRefusjonsopplysninger
 import no.nav.helse.person.Vedtaksperiode.Companion.førstePeriodeSomTrengerInntektTilVilkårsprøving
 import no.nav.helse.person.Vedtaksperiode.Companion.nestePeriodeSomSkalGjenopptas
@@ -733,6 +734,13 @@ internal class Arbeidsgiver private constructor(
                 sammenhengendePerioder.add(it)
         }
         return sammenhengendePerioder
+    }
+
+    // finner auuer før vedtaksperioden, men etter forrige avsluttede vedtaksperiode.
+    // brukes av spesialist for å avdekke totrinns, om noen av auu'ene har fått en overstyring
+    // som skal "dryppe over" på neste vedtaksperiode til godkjenning
+    internal fun finnAuuerIForkant(utgangspunkt: Vedtaksperiode): List<Vedtaksperiode> {
+        return vedtaksperioder.finnAuuerIForkant(utgangspunkt)
     }
 
     private fun addInntektsmelding(inntektsmelding: Inntektsmelding, dagoverstyring: Revurderingseventyr?) {

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Behandlinger.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Behandlinger.kt
@@ -132,12 +132,13 @@ internal class Behandlinger private constructor(behandlinger: List<Behandling>) 
         hendelse: IAktivitetslogg,
         erForlengelse: Boolean,
         perioderMedSammeSkjæringstidspunkt: List<Pair<UUID, Behandlinger>>,
+        auuerIForkant: List<UUID>,
         kanForkastes: Boolean,
         arbeidsgiverperiode: Arbeidsgiverperiode?,
         harPeriodeRettFør: Boolean
     ) {
         val behandlingerMedSammeSkjæringstidspunkt = perioderMedSammeSkjæringstidspunkt.map { it.first to it.second.behandlinger.last() }
-        behandlinger.last().godkjenning(hendelse, erForlengelse, behandlingerMedSammeSkjæringstidspunkt, kanForkastes, arbeidsgiverperiode, harPeriodeRettFør)
+        behandlinger.last().godkjenning(hendelse, erForlengelse, behandlingerMedSammeSkjæringstidspunkt, auuerIForkant, kanForkastes, arbeidsgiverperiode, harPeriodeRettFør)
     }
 
     internal fun håndterAnnullering(arbeidsgiver: Arbeidsgiver, hendelse: AnnullerUtbetaling, andreBehandlinger: List<Behandlinger>): Utbetaling? {
@@ -552,6 +553,7 @@ internal class Behandlinger private constructor(behandlinger: List<Behandling>) 
                 kanForkastes: Boolean,
                 behandling: Behandling,
                 perioderMedSammeSkjæringstidspunkt: List<Triple<UUID, UUID, Periode>>,
+                auuerIForkant: List<UUID>,
                 arbeidsgiverperiode: Arbeidsgiverperiode?,
                 harPeriodeRettFør: Boolean
             ) {
@@ -566,6 +568,7 @@ internal class Behandlinger private constructor(behandlinger: List<Behandling>) 
                     perioderMedSammeSkjæringstidspunkt.map { (vedtaksperiodeId, behandlingId, periode) ->
                         PeriodeMedSammeSkjæringstidspunkt(vedtaksperiodeId, behandlingId, periode)
                     },
+                    auuerIForkant,
                     hendelser
                 )
                 grunnlagsdata.byggGodkjenningsbehov(builder)
@@ -906,12 +909,13 @@ internal class Behandlinger private constructor(behandlinger: List<Behandling>) 
             hendelse: IAktivitetslogg,
             erForlengelse: Boolean,
             behandlingerMedSammeSkjæringstidspunkt: List<Pair<UUID, Behandling>>,
+            auuerIForkant: List<UUID>,
             kanForkastes: Boolean,
             arbeidsgiverperiode: Arbeidsgiverperiode?,
             harPeriodeRettFør: Boolean
         ) {
             val perioderMedSammeSkjæringstidspunkt = behandlingerMedSammeSkjæringstidspunkt.map { Triple(it.first, it.second.id, it.second.periode) }
-            gjeldende.godkjenning(hendelse, erForlengelse, kanForkastes, this, perioderMedSammeSkjæringstidspunkt, arbeidsgiverperiode, harPeriodeRettFør)
+            gjeldende.godkjenning(hendelse, erForlengelse, kanForkastes, this, perioderMedSammeSkjæringstidspunkt, auuerIForkant, arbeidsgiverperiode, harPeriodeRettFør)
         }
 
         fun annuller(arbeidsgiver: Arbeidsgiver, hendelse: AnnullerUtbetaling, behandlinger: List<Behandling>): Utbetaling? {

--- a/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
+++ b/sykepenger-model/src/main/kotlin/no/nav/helse/person/Person.kt
@@ -668,6 +668,8 @@ class Person private constructor(
         vilkårsgrunnlagHistorikk.lagre(vilkårsgrunnlag)
     }
 
+    internal fun auuerIForkant(utgangspunkt: Vedtaksperiode) = arbeidsgivere.flatMap { it.finnAuuerIForkant(utgangspunkt) }
+
     internal fun avklarSykepengegrunnlag(
         hendelse: IAktivitetslogg,
         skjæringstidspunkt: LocalDate,


### PR DESCRIPTION
dersom en saksbehandler gjør overstyring på en vedtaksperiode som medfører at perioden går til AUU, og samtidig får et annet skjæringstidspunkt enn perioden etterpå, så vil ikke AUU-en inngå i listen "perioderMedSammeSkjæringstidspunkt". På den måten vil ikke spesialist fange opp at det skal totrinnsvurderes noe.