### PR TITLE
Tillatt å opprette økonomiobjekter med 65% dekningsgrad

### DIFF
--- a/sykepenger-økonomi/src/main/kotlin/no/nav/helse/økonomi/Økonomi.kt
+++ b/sykepenger-økonomi/src/main/kotlin/no/nav/helse/økonomi/Økonomi.kt
@@ -151,10 +151,11 @@ data class Økonomi(
         }
         private val DekningsgradArbeidstaker = 100.prosent
         private val DekningsgradSelvstendig = 80.prosent
+        private val DekningsgradInaktiv = 65.prosent
     }
 
     init {
-        require(dekningsgrad == DekningsgradSelvstendig || dekningsgrad == DekningsgradArbeidstaker) { "dekningsgrad må være 100 % eller 80 % var $dekningsgrad." }
+        require(dekningsgrad == DekningsgradSelvstendig || dekningsgrad == DekningsgradArbeidstaker || dekningsgrad == DekningsgradInaktiv) { "dekningsgrad må være 100 %, 80 % eller 65 % var $dekningsgrad." }
     }
 
     // sykdomsgrader opprettes som int, og det gir ikke mening å runde opp og på den måten "gjøre personen mer syk"


### PR DESCRIPTION
Inaktive kan ha 65 % dekningsgrad